### PR TITLE
HCK0-45: Fix missing accent marks in landing page section components

### DIFF
--- a/components/landing/cta-section.tsx
+++ b/components/landing/cta-section.tsx
@@ -6,9 +6,7 @@ export function CTASection() {
 	return (
 		<section className="border-t py-16 md:py-20">
 			<div className="mx-auto max-w-screen-xl px-4 lg:px-8 text-center">
-				<h2 className="text-2xl font-semibold">
-					¿Tienes una comunidad tech?
-				</h2>
+				<h2 className="text-2xl font-semibold">¿Tienes una comunidad tech?</h2>
 				<p className="text-muted-foreground mt-2 max-w-md mx-auto">
 					Publica tus eventos gratis y dale visibilidad a tu comunidad. Sin
 					límites, sin costos, sin complicaciones.

--- a/components/landing/event-formats-section.tsx
+++ b/components/landing/event-formats-section.tsx
@@ -10,7 +10,7 @@ export function EventFormatsSection() {
 						Formatos de eventos
 					</p>
 					<h2 className="text-xl font-semibold mt-2">
-						Ritmo constante de activacion
+						Ritmo constante de activación
 					</h2>
 				</div>
 
@@ -24,8 +24,8 @@ export function EventFormatsSection() {
 						</div>
 						<h3 className="font-medium">Hacker House Sessions</h3>
 						<p className="text-xs text-muted-foreground mt-1">
-							Build nights, pair programming, office hours. Practica semanal sin
-							friccion.
+							Build nights, pair programming, office hours. Práctica semanal sin
+							fricción.
 						</p>
 					</div>
 
@@ -36,10 +36,10 @@ export function EventFormatsSection() {
 								Mensual
 							</Badge>
 						</div>
-						<h3 className="font-medium">Meetups Tecnicos</h3>
+						<h3 className="font-medium">Meetups Técnicos</h3>
 						<p className="text-xs text-muted-foreground mt-1">
 							Workshops, demos, talks y networking en diferentes ciudades del
-							pais.
+							país.
 						</p>
 					</div>
 
@@ -52,7 +52,7 @@ export function EventFormatsSection() {
 						</div>
 						<h3 className="font-medium">Hackatones 72h</h3>
 						<p className="text-xs text-muted-foreground mt-1">
-							Construccion intensa, premios, mentoria. Activar proyectos reales
+							Construcción intensa, premios, mentoría. Activar proyectos reales
 							y lanzar MVPs.
 						</p>
 					</div>

--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -13,7 +13,11 @@ interface HeroSectionProps {
 	countriesWithEvents?: string[];
 }
 
-export function HeroSection({ stats, departmentsWithEvents = [], countriesWithEvents = [] }: HeroSectionProps) {
+export function HeroSection({
+	stats,
+	departmentsWithEvents = [],
+	countriesWithEvents = [],
+}: HeroSectionProps) {
 	return (
 		<section className="border-b">
 			<div className="mx-auto max-w-screen-xl px-4 lg:px-8">
@@ -75,7 +79,10 @@ export function HeroSection({ stats, departmentsWithEvents = [], countriesWithEv
 
 					{/* Right side - Map */}
 					<div className="hidden lg:block h-[550px] xl:h-[600px]">
-						<LatamMap departmentsWithEvents={departmentsWithEvents} countriesWithEvents={countriesWithEvents} />
+						<LatamMap
+							departmentsWithEvents={departmentsWithEvents}
+							countriesWithEvents={countriesWithEvents}
+						/>
 					</div>
 				</div>
 			</div>

--- a/components/landing/latam-map.tsx
+++ b/components/landing/latam-map.tsx
@@ -13,8 +13,8 @@ import {
 	PERU_DEPARTMENT_NAME_MAP,
 } from "@/lib/geo/peru-departments";
 import worldData from "@/public/countries-110m.json";
-import peruDeptData from "@/public/peru_departamental_simple.json";
 import latamDotsData from "@/public/latam-dots.json";
+import peruDeptData from "@/public/peru_departamental_simple.json";
 import peruDotsData from "@/public/peru-dots.json";
 
 interface GeoFeature {
@@ -62,10 +62,15 @@ interface LatamMapProps {
 	countriesWithEvents?: string[];
 }
 
-export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] }: LatamMapProps) {
+export function LatamMap({
+	departmentsWithEvents = [],
+	countriesWithEvents = [],
+}: LatamMapProps) {
 	const router = useRouter();
 	const [hoveredCountryId, setHoveredCountryId] = useState<string | null>(null);
-	const [hoveredDepartment, setHoveredDepartment] = useState<string | null>(null);
+	const [hoveredDepartment, setHoveredDepartment] = useState<string | null>(
+		null,
+	);
 	const [zoomedCountryId, setZoomedCountryId] = useState<string | null>(null);
 
 	const countriesData = useMemo(() => {
@@ -170,7 +175,9 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 							{latamDotsData.map((country) => {
 								const isHovered = hoveredCountryId === country.countryId;
 								const isPeru = country.countryId === PERU_COUNTRY_ID;
-								const hasEvents = countriesWithEvents.includes(country.countryId);
+								const hasEvents = countriesWithEvents.includes(
+									country.countryId,
+								);
 								const countryFeature = countriesData.find(
 									(c) => c.id === country.countryId,
 								);
@@ -187,8 +194,16 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 											<path
 												d={geoPath(countryFeature as any) || ""}
 												fill="transparent"
-												stroke={isHovered && hasEvents ? "#888" : hasEvents ? "#666" : "#444"}
-												strokeWidth={isHovered && hasEvents ? 2 : hasEvents ? 1.5 : 1}
+												stroke={
+													isHovered && hasEvents
+														? "#888"
+														: hasEvents
+															? "#666"
+															: "#444"
+												}
+												strokeWidth={
+													isHovered && hasEvents ? 2 : hasEvents ? 1.5 : 1
+												}
 												opacity={isHovered ? 0.8 : hasEvents ? 0.6 : 0.35}
 												style={{ transition: "all 0.2s ease" }}
 											/>
@@ -196,7 +211,14 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 
 										{country.dots.map((dot, index) => {
 											const shouldAnimate = index % 5 === 0;
-											const baseOpacity = isHovered && hasEvents ? 0.85 : isHovered ? 0.6 : hasEvents ? 0.6 : 0.35;
+											const baseOpacity =
+												isHovered && hasEvents
+													? 0.85
+													: isHovered
+														? 0.6
+														: hasEvents
+															? 0.6
+															: 0.35;
 
 											if (shouldAnimate) {
 												return (
@@ -208,7 +230,11 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 														className="fill-foreground"
 														initial={{ opacity: baseOpacity }}
 														animate={{
-															opacity: [baseOpacity, baseOpacity + 0.3, baseOpacity],
+															opacity: [
+																baseOpacity,
+																baseOpacity + 0.3,
+																baseOpacity,
+															],
 															scale: [1, 1.3, 1],
 														}}
 														transition={{
@@ -255,7 +281,8 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 						>
 							{peruDepartments.map((dept, deptIndex) => {
 								const deptName = dept.properties?.NOMBDEP || "";
-								const normalizedName = PERU_DEPARTMENT_NAME_MAP[deptName] || deptName;
+								const normalizedName =
+									PERU_DEPARTMENT_NAME_MAP[deptName] || deptName;
 								const hasEvent = departmentsWithEvents.includes(normalizedName);
 								const isHovered = hoveredDepartment === normalizedName;
 
@@ -264,15 +291,26 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 										key={dept.properties?.NOMBDEP || deptIndex}
 										d={peruGeoPath(dept as any) || ""}
 										fill="transparent"
-										stroke={isHovered && hasEvent ? "#888" : hasEvent ? "#666" : "#444"}
+										stroke={
+											isHovered && hasEvent
+												? "#888"
+												: hasEvent
+													? "#666"
+													: "#444"
+										}
 										strokeWidth={isHovered && hasEvent ? 2 : hasEvent ? 1.5 : 1}
 										opacity={isHovered ? 0.8 : hasEvent ? 0.6 : 0.35}
-										style={{ cursor: hasEvent ? "pointer" : "default", transition: "all 0.2s ease" }}
+										style={{
+											cursor: hasEvent ? "pointer" : "default",
+											transition: "all 0.2s ease",
+										}}
 										onMouseEnter={() => setHoveredDepartment(normalizedName)}
 										onMouseLeave={() => setHoveredDepartment(null)}
 										onClick={() => {
 											if (hasEvent) {
-												router.push(`/events?department=${encodeURIComponent(normalizedName)}`);
+												router.push(
+													`/events?department=${encodeURIComponent(normalizedName)}`,
+												);
 											}
 										}}
 									/>
@@ -283,7 +321,14 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 								const hasEvent = departmentsWithEvents.includes(dot.dept);
 								const isHovered = hoveredDepartment === dot.dept;
 								const shouldAnimate = index % 5 === 0;
-								const baseOpacity = isHovered && hasEvent ? 0.85 : isHovered ? 0.6 : hasEvent ? 0.6 : 0.35;
+								const baseOpacity =
+									isHovered && hasEvent
+										? 0.85
+										: isHovered
+											? 0.6
+											: hasEvent
+												? 0.6
+												: 0.35;
 
 								if (shouldAnimate) {
 									return (
@@ -317,7 +362,10 @@ export function LatamMap({ departmentsWithEvents = [], countriesWithEvents = [] 
 										r={1.5}
 										className="fill-foreground"
 										opacity={baseOpacity}
-										style={{ pointerEvents: "none", transition: "opacity 0.2s ease" }}
+										style={{
+											pointerEvents: "none",
+											transition: "opacity 0.2s ease",
+										}}
 									/>
 								);
 							})}

--- a/components/landing/mission-section.tsx
+++ b/components/landing/mission-section.tsx
@@ -7,9 +7,11 @@ export function MissionSection() {
 			<div className="mx-auto max-w-screen-xl px-4 lg:px-8">
 				<div className="text-center mb-8">
 					<p className="text-xs text-muted-foreground uppercase tracking-wide">
-						Nuestra mision
+						Nuestra misión
 					</p>
-					<h2 className="text-xl font-semibold mt-2">Dos caminos, un objetivo</h2>
+					<h2 className="text-xl font-semibold mt-2">
+						Dos caminos, un objetivo
+					</h2>
 				</div>
 
 				<div className="grid md:grid-cols-2 gap-4">
@@ -32,9 +34,9 @@ export function MissionSection() {
 								Acelerar el primer unicornio peruano
 							</h3>
 							<p className="text-sm text-muted-foreground mt-2">
-								Si logramos activar a miles de nuevos builders en el pais,
-								podriamos acelerar el surgimiento del primer unicornio peruano y
-								fomentar un ecosistema tecnologico autosuficiente desde abajo
+								Si logramos activar a miles de nuevos builders en el país,
+								podríamos acelerar el surgimiento del primer unicornio peruano y
+								fomentar un ecosistema tecnológico autosuficiente desde abajo
 								hacia arriba.
 							</p>
 						</div>
@@ -46,12 +48,12 @@ export function MissionSection() {
 							<Badge variant="outline">Realista</Badge>
 						</div>
 						<h3 className="text-lg font-medium">
-							Mejores oportunidades para jovenes
+							Mejores oportunidades para jóvenes
 						</h3>
 						<p className="text-sm text-muted-foreground mt-2">
-							Brindar a jovenes las herramientas y la comunidad para aprender
-							rapido, lanzar productos y conseguir mejores oportunidades
-							laborales, freelance o de emprendimiento desde Peru o hacia el
+							Brindar a jóvenes las herramientas y la comunidad para aprender
+							rápido, lanzar productos y conseguir mejores oportunidades
+							laborales, freelance o de emprendimiento desde Perú o hacia el
 							mundo.
 						</p>
 					</div>

--- a/components/landing/pillars-section.tsx
+++ b/components/landing/pillars-section.tsx
@@ -9,7 +9,7 @@ export function PillarsSection() {
 						Dos pilares
 					</p>
 					<h2 className="text-xl font-semibold mt-2">
-						Comunidad + Espacio fisico
+						Comunidad + Espacio físico
 					</h2>
 				</div>
 
@@ -25,13 +25,13 @@ export function PillarsSection() {
 						</div>
 						<h3 className="text-lg font-medium">Red distribuida de builders</h3>
 						<p className="text-sm text-muted-foreground mt-2">
-							Sistema distribuido de aprendizaje, conexion y lanzamiento. Opera
-							bajo logica descentralizada y de alta frecuencia.
+							Sistema distribuido de aprendizaje, conexión y lanzamiento. Opera
+							bajo lógica descentralizada y de alta frecuencia.
 						</p>
 						<ul className="mt-4 space-y-2 text-sm text-muted-foreground">
 							<li className="flex items-center gap-2">
 								<span className="h-1 w-1 rounded-full bg-emerald-500" />
-								Eventos en todo Peru
+								Eventos en todo Perú
 							</li>
 							<li className="flex items-center gap-2">
 								<span className="h-1 w-1 rounded-full bg-emerald-500" />
@@ -53,9 +53,9 @@ export function PillarsSection() {
 								Hacker House
 							</span>
 						</div>
-						<h3 className="text-lg font-medium">Espacio fisico para crear</h3>
+						<h3 className="text-lg font-medium">Espacio físico para crear</h3>
 						<p className="text-sm text-muted-foreground mt-2">
-							Nucleo intensivo del ecosistema. Un espacio fisico, experimental y
+							Núcleo intensivo del ecosistema. Un espacio físico, experimental y
 							habitado donde convergen builders comprometidos.
 						</p>
 						<ul className="mt-4 space-y-2 text-sm text-muted-foreground">

--- a/components/landing/values-section.tsx
+++ b/components/landing/values-section.tsx
@@ -4,7 +4,8 @@ const values = [
 	{
 		icon: Code,
 		title: "Indie Hacker Mindset",
-		description: "Crear con poco, escalar con ingenio. Construimos productos, no slides.",
+		description:
+			"Crear con poco, escalar con ingenio. Construimos productos, no slides.",
 	},
 	{
 		icon: HandHeart,
@@ -20,9 +21,9 @@ const values = [
 	},
 	{
 		icon: Users,
-		title: "Colaboracion Real",
+		title: "Colaboración Real",
 		description:
-			"Sin gurus, sin gatekeeping. Colaboracion genuina entre pares.",
+			"Sin gurús, sin gatekeeping. Colaboración genuina entre pares.",
 	},
 ];
 
@@ -34,7 +35,7 @@ export function ValuesSection() {
 					<p className="text-xs text-muted-foreground uppercase tracking-wide">
 						Valores
 					</p>
-					<h2 className="text-xl font-semibold mt-2">Como construimos</h2>
+					<h2 className="text-xl font-semibold mt-2">Cómo construimos</h2>
 				</div>
 
 				<div className="grid grid-cols-2 md:grid-cols-4 gap-4">


### PR DESCRIPTION
Resolves HCK0-45

## Changes
Fixed missing accent marks (tildes) in Spanish text across 5 landing section components:

### mission-section.tsx
- "mision" → "misión"
- "pais" → "país" 
- "podriamos" → "podríamos"
- "tecnologico" → "tecnológico"
- "jovenes" → "jóvenes"
- "rapido" → "rápido"
- "Peru" → "Perú"

### pillars-section.tsx
- "fisico" → "físico" (2 occurrences)
- "conexion" → "conexión"
- "logica" → "lógica"
- "Peru" → "Perú"
- "Nucleo" → "Núcleo"

### event-formats-section.tsx
- "activacion" → "activación"
- "Practica" → "Práctica"
- "friccion" → "fricción"
- "Tecnicos" → "Técnicos"
- "pais" → "país"
- "Construccion" → "Construcción"
- "mentoria" → "mentoría"

### values-section.tsx
- "Colaboracion" → "Colaboración" (2 occurrences)
- "gurus" → "gurús"
- "Como" → "Cómo"

### tools-section.tsx
✅ No changes needed - already correct

## Testing
- ✅ Ran \`bun check\` - no lint errors
- ✅ Applied Biome auto-formatting for consistency

🤖 Generated with Claude Code