### PR TITLE
feat: add /health endpoint for system monitoring (HCK0-48)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import packageJson from "@/package.json";
+
+export async function GET() {
+	const runtime = typeof Bun !== "undefined" ? `bun ${Bun.version}` : `node ${process.version}`;
+
+	return NextResponse.json({
+		status: "ok",
+		version: packageJson.version,
+		uptime: process.uptime(),
+		runtime,
+		timestamp: new Date().toISOString(),
+	});
+}


### PR DESCRIPTION
## Summary

Implements a health check endpoint at `GET /api/health` for system monitoring and deployment verification.

## Changes

- Created `app/api/health/route.ts` with GET handler
- Returns JSON with system status, version, uptime, runtime, and timestamp

## Response Format

```json
{
  "status": "ok",
  "version": "0.1.0",
  "uptime": 12345,
  "runtime": "bun 1.2.2",
  "timestamp": "2026-02-10T..."
}
```

## Testing

- ✅ Biome linter passed
- Endpoint is publicly accessible (no auth required)
- Compatible with both Bun and Node.js runtimes

Resolves HCK0-48