### PR TITLE
feat: add aria-current attribute to active nav links (HCK0-72)

### DIFF
--- a/components/layout/main-nav.tsx
+++ b/components/layout/main-nav.tsx
@@ -24,6 +24,7 @@ export function MainNav() {
 					<Link
 						key={item.href}
 						href={item.href}
+						aria-current={isActive ? "page" : undefined}
 						className={`transition-colors ${
 							isActive
 								? "text-foreground"

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -67,6 +67,7 @@ export function MobileNav() {
 										key={item.href}
 										href={item.href}
 										onClick={() => setOpen(false)}
+										aria-current={isActive ? "page" : undefined}
 										className={`
 											block py-3 text-xl font-medium tracking-tight transition-colors
 											${isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground"}
@@ -82,8 +83,9 @@ export function MobileNav() {
 							<p className="text-xs text-muted-foreground uppercase tracking-wider mb-4">
 								Recursos
 							</p>
-							{secondaryItems.map((item) =>
-								item.external ? (
+							{secondaryItems.map((item) => {
+								const isActive = !item.external && pathname === item.href;
+								return item.external ? (
 									<a
 										key={item.href}
 										href={item.href}
@@ -97,12 +99,13 @@ export function MobileNav() {
 										key={item.href}
 										href={item.href}
 										onClick={() => setOpen(false)}
+										aria-current={isActive ? "page" : undefined}
 										className="block py-2 text-base text-muted-foreground hover:text-foreground transition-colors"
 									>
 										{item.label}
 									</Link>
-								),
-							)}
+								);
+							})}
 						</div>
 					</nav>
 


### PR DESCRIPTION
## Summary
Add `aria-current="page"` attribute to active navigation links for improved accessibility.

## Changes
- **MainNav** (`components/layout/main-nav.tsx`): Add `aria-current` to desktop navigation links
- **MobileNav** (`components/layout/mobile-nav.tsx`): Add `aria-current` to both primary and secondary navigation items

## Testing
- Verify that active navigation links have `aria-current="page"` attribute
- Confirm screen readers correctly announce the current page

Resolves HCK0-72