### PR TITLE
feat: add timezone selector and fix timezone conversion bug

### DIFF
--- a/components/org/creation/org-event-form-minimal.tsx
+++ b/components/org/creation/org-event-form-minimal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRealtimeRun } from "@trigger.dev/react-hooks";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import {
 	ArrowLeft,
 	Building2,
@@ -73,7 +74,11 @@ import {
 	getEventTypeConfig,
 	hasEventOptions,
 } from "@/lib/event-type-config";
-import { SKILL_LEVEL_OPTIONS } from "@/lib/event-utils";
+import {
+	DEFAULT_TIMEZONE,
+	SKILL_LEVEL_OPTIONS,
+	TIMEZONE_OPTIONS,
+} from "@/lib/event-utils";
 import type { ExtractedEventData } from "@/lib/schemas/event-extraction";
 import type { eventImportTask } from "@/trigger/event-import";
 import { AIExtractModal } from "./ai-extract-modal";
@@ -120,14 +125,16 @@ export function OrgEventFormMinimal({
 }: OrgEventFormMinimalProps) {
 	const router = useRouter();
 	const isEditMode = mode === "edit";
+	const initialTimezone = event?.timezone || DEFAULT_TIMEZONE;
 
 	const parseDateTime = (dateValue: Date | string | null | undefined) => {
 		if (!dateValue) return { date: "", time: "" };
 		try {
 			const date = new Date(dateValue);
-			const dateStr = date.toISOString().split("T")[0];
-			const timeStr = date.toTimeString().slice(0, 5);
-			return { date: dateStr, time: timeStr };
+			return {
+				date: formatInTimeZone(date, initialTimezone, "yyyy-MM-dd"),
+				time: formatInTimeZone(date, initialTimezone, "HH:mm"),
+			};
 		} catch {
 			return { date: "", time: "" };
 		}
@@ -180,6 +187,7 @@ export function OrgEventFormMinimal({
 	const [skillLevel, setSkillLevel] = useState<SkillLevel>(
 		event?.skillLevel || "all",
 	);
+	const [timezone, setTimezone] = useState(initialTimezone);
 	const [linksOpen, setLinksOpen] = useState(false);
 	const [locationOpen, setLocationOpen] = useState(false);
 	const [optionsOpen, setOptionsOpen] = useState(false);
@@ -235,14 +243,22 @@ export function OrgEventFormMinimal({
 				name,
 				description: description || undefined,
 				startDate: startDate
-					? new Date(`${startDate}T${startTime || "00:00"}`)
+					? fromZonedTime(
+							`${startDate}T${startTime || "00:00"}`,
+							timezone || DEFAULT_TIMEZONE,
+						)
 					: null,
-				endDate: endDate ? new Date(`${endDate}T${endTime || "23:59"}`) : null,
+				endDate: endDate
+					? fromZonedTime(
+							`${endDate}T${endTime || "23:59"}`,
+							timezone || DEFAULT_TIMEZONE,
+						)
+					: null,
 				format,
 				department: department || undefined,
 				city: city || undefined,
 				venue: venue || undefined,
-				timezone: "America/Lima",
+				timezone: timezone || DEFAULT_TIMEZONE,
 				geoLatitude: geoLatitude || undefined,
 				geoLongitude: geoLongitude || undefined,
 				meetingUrl: meetingUrl || undefined,
@@ -274,7 +290,7 @@ export function OrgEventFormMinimal({
 				department: department || undefined,
 				city: city || undefined,
 				venue: venue || undefined,
-				timezone: "America/Lima",
+				timezone: timezone || DEFAULT_TIMEZONE,
 				geoLatitude: geoLatitude || undefined,
 				geoLongitude: geoLongitude || undefined,
 				meetingUrl: meetingUrl || undefined,
@@ -844,6 +860,25 @@ export function OrgEventFormMinimal({
 								className={`h-8 text-sm w-24 ${isImporting ? "input-shimmer" : ""}`}
 								disabled={isImporting}
 							/>
+						</div>
+
+						<div className="border-t border-border" />
+
+						<div className="p-3 flex items-center gap-3">
+							<Globe className="h-4 w-4 text-muted-foreground/50" />
+							<Label className="text-sm text-muted-foreground w-12">
+								Zona Horaria
+							</Label>
+							<div className="flex-1 min-w-0">
+								<SearchableSelect
+									options={TIMEZONE_OPTIONS}
+									value={timezone}
+									onValueChange={setTimezone}
+									placeholder="Zona horaria"
+									searchPlaceholder="Buscar zona horaria..."
+									emptyMessage="No se encontró"
+								/>
+							</div>
 						</div>
 					</div>
 

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { auth } from "@clerk/nextjs/server";
+import { fromZonedTime } from "date-fns-tz";
 import {
 	and,
 	asc,
@@ -675,10 +676,17 @@ export async function createEvent(
 			geoLatitude: input.geoLatitude,
 			geoLongitude: input.geoLongitude,
 			meetingUrl: input.meetingUrl,
-			startDate: input.startDate ? new Date(input.startDate) : undefined,
-			endDate: input.endDate ? new Date(input.endDate) : undefined,
+			startDate: input.startDate
+				? fromZonedTime(input.startDate, input.timezone || "America/Lima")
+				: undefined,
+			endDate: input.endDate
+				? fromZonedTime(input.endDate, input.timezone || "America/Lima")
+				: undefined,
 			registrationDeadline: input.registrationDeadline
-				? new Date(input.registrationDeadline)
+				? fromZonedTime(
+						input.registrationDeadline,
+						input.timezone || "America/Lima",
+					)
 				: undefined,
 			prizePool: input.prizePool,
 			prizeCurrency: input.prizeCurrency || "USD",

--- a/lib/event-utils.ts
+++ b/lib/event-utils.ts
@@ -394,28 +394,29 @@ export function formatCalendarMonth(
 	return formatTz(date, formatStr, { locale: es, timeZone: tz });
 }
 
+export const TIMEZONE_ABBRS: Record<string, string> = {
+	"America/Lima": "PET",
+	"America/Bogota": "COT",
+	"America/Mexico_City": "CST",
+	"America/Guatemala": "CST",
+	"America/Argentina/Buenos_Aires": "ART",
+	"America/Santiago": "CLT",
+	"America/Sao_Paulo": "BRT",
+	"America/Guayaquil": "ECT",
+	"America/Caracas": "VET",
+	"America/Panama": "EST",
+	"America/Asuncion": "PYT",
+	"America/Montevideo": "UYT",
+	"America/La_Paz": "BOT",
+	"America/Costa_Rica": "CST",
+	"America/Managua": "CST",
+	"America/Tegucigalpa": "CST",
+	"America/El_Salvador": "CST",
+	"America/Santo_Domingo": "AST",
+	"America/Havana": "CST",
+};
+
 export function getTimezoneAbbreviation(tz: string): string {
-	const TIMEZONE_ABBRS: Record<string, string> = {
-		"America/Lima": "PET",
-		"America/Bogota": "COT",
-		"America/Mexico_City": "CST",
-		"America/Guatemala": "CST",
-		"America/Argentina/Buenos_Aires": "ART",
-		"America/Santiago": "CLT",
-		"America/Sao_Paulo": "BRT",
-		"America/Guayaquil": "ECT",
-		"America/Caracas": "VET",
-		"America/Panama": "EST",
-		"America/Asuncion": "PYT",
-		"America/Montevideo": "UYT",
-		"America/La_Paz": "BOT",
-		"America/Costa_Rica": "CST",
-		"America/Managua": "CST",
-		"America/Tegucigalpa": "CST",
-		"America/El_Salvador": "CST",
-		"America/Santo_Domingo": "AST",
-		"America/Havana": "CST",
-	};
 	return TIMEZONE_ABBRS[tz] || tz.split("/").pop()?.replace(/_/g, " ") || tz;
 }
 
@@ -441,6 +442,13 @@ export const STATUS_OPTIONS = Object.entries(STATUS_LABELS).map(
 
 export const COUNTRY_OPTIONS = Object.entries(COUNTRY_NAMES).map(
 	([code, name]) => ({ value: code, label: `${getCountryFlag(code)} ${name}` }),
+);
+
+export const TIMEZONE_OPTIONS = Object.entries(TIMEZONE_ABBRS).map(
+	([value, abbr]) => ({
+		value,
+		label: `${value.split("/").pop()?.replace(/_/g, " ")} (${abbr})`,
+	}),
 );
 
 // Peru departments/regions for filtering


### PR DESCRIPTION
## Summary

- Add a LATAM timezone selector (19 timezones) to the event creation/edit form using `SearchableSelect`
- Fix bug where event dates were stored with wrong UTC offset due to timezone-unaware parsing

## Bug Details

When creating an event with a non-default timezone, dates were stored incorrectly. The form sent bare datetime strings (e.g. `2026-03-28T22:45`) which `new Date()` parsed in the server's local timezone instead of the event's selected timezone.

**Example:** Creating an event at **10:45 PM Buenos Aires (ART, UTC-3)**:
- **Expected in DB:** `2026-03-29T01:45:00Z` (22:45 + 3h)
- **Actual in DB:** `2026-03-29T03:45:00Z` (parsed as server timezone UTC-5 instead)

This caused the detail page to show **"domingo 29 de marzo, 12:45 AM (ART)"** instead of the correct **"sábado 28 de marzo, 10:45 PM (ART)"**, and the countdown to display ~4h 52m instead of ~2h 52m.

## Fix

Use `fromZonedTime()` from `date-fns-tz` to properly convert local event times to UTC before storage, in both `createEvent` and `updateEvent` flows.

## Files Changed

- `lib/event-utils.ts` — Export `TIMEZONE_ABBRS` at module level, add `TIMEZONE_OPTIONS`
- `lib/actions/events.ts` — Use `fromZonedTime()` for date conversion in `createEvent`
- `components/org/creation/org-event-form-minimal.tsx` — Add timezone selector, use `fromZonedTime()` in edit mode

## Test plan

- [ ] Create event with Buenos Aires timezone at a specific time, verify DB stores correct UTC
- [ ] Verify detail page shows the time in the event's timezone with correct label (ART)
- [ ] Verify countdown shows correct time remaining relative to viewer's local time
- [ ] Edit an existing event, verify timezone pre-populates correctly
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)