### PR TITLE
fix: harden Luma calendar sync

### DIFF
--- a/lib/luma/calendar-sync.ts
+++ b/lib/luma/calendar-sync.ts
@@ -17,6 +17,20 @@ type LumaHost = {
 	avatar_url?: string | null;
 };
 
+type LumaGeoAddress = {
+	city?: string | null;
+	region?: string | null;
+	country?: string | null;
+	country_code?: string | null;
+	address?: string | null;
+	description?: string | null;
+	latitude?: number | string | null;
+	longitude?: number | string | null;
+	full_address?: string | null;
+	short_address?: string | null;
+	mode?: string | null;
+};
+
 type LumaEvent = {
 	id?: string;
 	api_id?: string;
@@ -29,29 +43,8 @@ type LumaEvent = {
 	url: string;
 	cover_url?: string | null;
 	meeting_url?: string | null;
-	geo_address_json?: {
-		city?: string | null;
-		region?: string | null;
-		country?: string | null;
-		country_code?: string | null;
-		address?: string | null;
-		description?: string | null;
-		latitude?: string | null;
-		longitude?: string | null;
-		full_address?: string | null;
-		short_address?: string | null;
-	} | null;
-	geo_address_info?: {
-		city?: string | null;
-		region?: string | null;
-		country?: string | null;
-		country_code?: string | null;
-		address?: string | null;
-		description?: string | null;
-		full_address?: string | null;
-		short_address?: string | null;
-		mode?: string | null;
-	} | null;
+	geo_address_json?: LumaGeoAddress | null;
+	geo_address_info?: LumaGeoAddress | null;
 	coordinate?: {
 		latitude?: number | string | null;
 		longitude?: number | string | null;
@@ -129,6 +122,14 @@ function normalizeEventUrl(event: LumaEvent) {
 function truncate(value: string | null | undefined, max: number) {
 	if (!value) return null;
 	return value.length > max ? value.slice(0, max) : value;
+}
+
+function coordinateValue(...values: Array<number | string | null | undefined>) {
+	const value = values.find(
+		(candidate) => candidate !== null && candidate !== undefined,
+	);
+	if (value === null || value === undefined) return null;
+	return String(value);
 }
 
 function durationEndDate(startDate: Date | null, interval?: string | null) {
@@ -413,15 +414,17 @@ async function syncEvent(
 					255,
 				),
 				geoLatitude:
-					detailedEvent.geo_latitude ||
-					geo?.latitude ||
-					detailedEvent.coordinate?.latitude?.toString() ||
-					existing.geoLatitude,
+					coordinateValue(
+						detailedEvent.geo_latitude,
+						geo?.latitude,
+						detailedEvent.coordinate?.latitude,
+					) || existing.geoLatitude,
 				geoLongitude:
-					detailedEvent.geo_longitude ||
-					geo?.longitude ||
-					detailedEvent.coordinate?.longitude?.toString() ||
-					existing.geoLongitude,
+					coordinateValue(
+						detailedEvent.geo_longitude,
+						geo?.longitude,
+						detailedEvent.coordinate?.longitude,
+					) || existing.geoLongitude,
 				meetingUrl,
 				registrationUrl: detailedEvent.url,
 				eventImageUrl: detailedEvent.cover_url || existing.eventImageUrl,
@@ -467,15 +470,17 @@ async function syncEvent(
 				255,
 			),
 			geoLatitude:
-				detailedEvent.geo_latitude ||
-				geo?.latitude ||
-				detailedEvent.coordinate?.latitude?.toString() ||
-				null,
+				coordinateValue(
+					detailedEvent.geo_latitude,
+					geo?.latitude,
+					detailedEvent.coordinate?.latitude,
+				) || null,
 			geoLongitude:
-				detailedEvent.geo_longitude ||
-				geo?.longitude ||
-				detailedEvent.coordinate?.longitude?.toString() ||
-				null,
+				coordinateValue(
+					detailedEvent.geo_longitude,
+					geo?.longitude,
+					detailedEvent.coordinate?.longitude,
+				) || null,
 			meetingUrl,
 			websiteUrl: detailedEvent.url,
 			registrationUrl: detailedEvent.url,

--- a/lib/scraper/luma-schema.ts
+++ b/lib/scraper/luma-schema.ts
@@ -83,8 +83,31 @@ export interface LumaExtractedData {
 	organizerName?: string;
 	registrationUrl?: string;
 	price?: string;
-	eventType?: string;
+	eventType?: EventType;
 }
+
+export const EVENT_TYPES = [
+	"hackathon",
+	"conference",
+	"seminar",
+	"research_fair",
+	"workshop",
+	"bootcamp",
+	"summer_school",
+	"course",
+	"certification",
+	"meetup",
+	"networking",
+	"olympiad",
+	"competition",
+	"robotics",
+	"accelerator",
+	"incubator",
+	"fellowship",
+	"call_for_papers",
+] as const;
+
+export type EventType = (typeof EVENT_TYPES)[number];
 
 export function isLumaUrl(url: string): boolean {
 	try {
@@ -113,7 +136,7 @@ export function normalizeLumaUrl(url: string): string {
 	}
 }
 
-export function inferEventType(name: string, description?: string): string {
+export function inferEventType(name: string, description?: string): EventType {
 	const text = `${name} ${description || ""}`.toLowerCase();
 
 	if (text.includes("hackathon") || text.includes("hackatón"))

--- a/scripts/sync-luma-calendar.ts
+++ b/scripts/sync-luma-calendar.ts
@@ -15,6 +15,13 @@ const dryRun = process.argv.includes("--dry-run");
 const includePast = !process.argv.includes("--future-only");
 const limitArg = process.argv.find((arg) => arg.startsWith("--limit="));
 const limit = limitArg ? Number(limitArg.split("=")[1]) : 50;
-const result = await syncLumaCalendarEvents({ dryRun, includePast, limit });
 
-console.log(JSON.stringify(result, null, 2));
+async function main() {
+	const result = await syncLumaCalendarEvents({ dryRun, includePast, limit });
+	console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- types Luma event classification against the DB event enum instead of plain strings
- normalizes Luma geo payloads across `geo_address_json`, `geo_address_info`, and `coordinate`
- wraps the Luma sync script in an explicit CLI entrypoint so it passes project TypeScript constraints

## Luma backfill verification
- `bun run sync:luma -- --dry-run --limit=500` fetched 189, updated 187, skipped 2 internal/private events
- `bun run sync:luma -- --limit=500` completed against Neon with the same totals
- DB check after sync: 187 events with `scrape_source = luma_public`, 537 Luma hosts

## Notes
- Luma official `calendar/list-events` only returned 49 calendar items in this account, while the public calendar feed returned 189. Keeping the public calendar feed is required for the full hack0 public backfill. Event details still use the official public API when Luma event ids exist.

## Checks
- `bunx biome check --write lib/luma/calendar-sync.ts lib/scraper/luma-schema.ts scripts/sync-luma-calendar.ts`
- `bun run sync:luma -- --dry-run --limit=5`
- `bun run sync:luma -- --dry-run --limit=500`
- `bun run sync:luma -- --limit=500`
- `bun run build`
- `bun --bun tsc --noEmit --pretty false` fails on existing non-Luma debt; Luma sync/script errors are gone
