### PR TITLE
fix: sanitize public filter boundaries

### DIFF
--- a/app/(app)/api/organizations/route.ts
+++ b/app/(app)/api/organizations/route.ts
@@ -3,16 +3,12 @@ import { and, asc, count, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { communityMembers, organizations } from "@/lib/db/schema";
-import { ORGANIZER_TYPES, type OrganizerType } from "@/lib/db/schema/constants";
+import { isOrganizerType } from "@/lib/db/schema/constants";
 
 const DEFAULT_LIMIT = 12;
 const MAX_LIMIT = 50;
 
 type OrderBy = "popular" | "recent" | "name" | "contact" | "contact_asc";
-
-function isOrganizerType(value: string): value is OrganizerType {
-	return (ORGANIZER_TYPES as readonly string[]).includes(value);
-}
 
 export async function GET(request: NextRequest) {
 	try {

--- a/app/(app)/c/[slug]/(with-header)/page.tsx
+++ b/app/(app)/c/[slug]/(with-header)/page.tsx
@@ -20,6 +20,8 @@ interface CommunityPageProps {
 	searchParams: Promise<SearchParams>;
 }
 
+export const dynamic = "force-dynamic";
+
 type ViewMode = "table" | "cards" | "calendar" | "map" | "preview";
 
 async function CommunityEvents({

--- a/app/(app)/c/discover/page.tsx
+++ b/app/(app)/c/discover/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/actions/communities";
 import { db } from "@/lib/db";
 import { communityMembers, organizations } from "@/lib/db/schema";
-import { ORGANIZER_TYPES, type OrganizerType } from "@/lib/db/schema/constants";
+import { isCountryCode, isOrganizerType } from "@/lib/db/schema/constants";
 import { getCommunitiesViewPreference } from "@/lib/view-preferences";
 
 interface DiscoverPageProps {
@@ -46,11 +46,9 @@ export const metadata = {
 		"Descubre comunidades de tecnología, hackathons y eventos en Perú. Únete a la comunidad tech más activa.",
 };
 
-const INITIAL_LIMIT = 12;
+export const dynamic = "force-dynamic";
 
-function isOrganizerType(value: string): value is OrganizerType {
-	return (ORGANIZER_TYPES as readonly string[]).includes(value);
-}
+const INITIAL_LIMIT = 12;
 
 async function getInitialCommunities(
 	params: {
@@ -69,7 +67,8 @@ async function getInitialCommunities(
 	const type =
 		params.type && isOrganizerType(params.type) ? params.type : undefined;
 	const typesArray = params.types?.split(",").filter(isOrganizerType) || [];
-	const countriesArray = params.countries?.split(",").filter(Boolean) || [];
+	const countriesArray =
+		params.countries?.split(",").filter(isCountryCode) || [];
 	const verifiedOnly = params.verified === "true";
 
 	const conditions = [
@@ -201,7 +200,8 @@ export default async function DiscoverPage({
 	const { userId } = await auth();
 	const params = await searchParams;
 
-	const countriesArray = params.countries?.split(",").filter(Boolean) || [];
+	const countriesArray =
+		params.countries?.split(",").filter(isCountryCode) || [];
 	const typesArray = params.types?.split(",").filter(Boolean) || [];
 	const sizesArray = params.sizes?.split(",").filter(Boolean) || [];
 	const verificationArray =

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -38,6 +38,8 @@ export const metadata: Metadata = {
 		"Directorio público de eventos, comunidades, hackathons, labs, grants y builders de IA en Perú.",
 };
 
+export const dynamic = "force-dynamic";
+
 const PERU = "PE";
 const HACKATHON_TYPES = [
 	"hackathon",

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -18,6 +18,8 @@ interface EventsPageProps {
 	searchParams: Promise<SearchParams>;
 }
 
+export const dynamic = "force-dynamic";
+
 async function EventsContent({
 	filters,
 	viewMode,

--- a/components/events/edit/edit-event-form.tsx
+++ b/components/events/edit/edit-event-form.tsx
@@ -23,6 +23,12 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { type EventSponsorWithOrg, updateEvent } from "@/lib/actions/events";
 import type { Event } from "@/lib/db/schema";
+import {
+	type EventType,
+	isEventType,
+	isSkillLevel,
+	type SkillLevel,
+} from "@/lib/db/schema/constants";
 import { EVENT_TYPE_OPTIONS, SKILL_LEVEL_OPTIONS } from "@/lib/event-utils";
 import { DateRangeInput } from "./date-range-input";
 import { FormatSelector } from "./format-selector";
@@ -100,10 +106,10 @@ export function EditEventForm({
 		event.registrationUrl || "",
 	);
 	const [eventImageUrl, setEventImageUrl] = useState(event.eventImageUrl || "");
-	const [eventType, setEventType] = useState<string>(
+	const [eventType, setEventType] = useState<EventType>(
 		event.eventType || "hackathon",
 	);
-	const [skillLevel, setSkillLevel] = useState<string>(
+	const [skillLevel, setSkillLevel] = useState<SkillLevel>(
 		event.skillLevel || "all",
 	);
 
@@ -212,7 +218,9 @@ export function EditEventForm({
 									<SearchableSelect
 										options={EVENT_TYPE_OPTIONS}
 										value={eventType}
-										onValueChange={setEventType}
+										onValueChange={(value) => {
+											if (isEventType(value)) setEventType(value);
+										}}
 										placeholder="Seleccionar tipo..."
 										searchPlaceholder="Buscar tipo de evento..."
 										emptyMessage="No se encontró ningún tipo"
@@ -221,7 +229,12 @@ export function EditEventForm({
 
 								<Field>
 									<FieldLabel htmlFor="skillLevel">Nivel requerido</FieldLabel>
-									<Select value={skillLevel} onValueChange={setSkillLevel}>
+									<Select
+										value={skillLevel}
+										onValueChange={(value) => {
+											if (isSkillLevel(value)) setSkillLevel(value);
+										}}
+									>
 										<SelectTrigger id="skillLevel">
 											<SelectValue />
 										</SelectTrigger>

--- a/components/events/toolbar/events-toolbar.tsx
+++ b/components/events/toolbar/events-toolbar.tsx
@@ -3,6 +3,15 @@
 import { Search, X } from "lucide-react";
 import { useQueryStates } from "nuqs";
 import { useState } from "react";
+import {
+	DOMAINS,
+	EVENT_TYPES,
+	FORMATS,
+	filterEnumValues,
+	LATAM_COUNTRY_CODES,
+	ORGANIZER_TYPES,
+	SKILL_LEVELS,
+} from "@/lib/db/schema/constants";
 import { searchParamsParsers } from "@/lib/search-params";
 import { EventsFiltersPopover } from "./events-filters-popover";
 import { EventsViewSelector } from "./events-view-selector";
@@ -29,6 +38,18 @@ export function EventsToolbar() {
 		mine,
 		timeFilter,
 	} = filters;
+	const sanitizedFilters = {
+		eventType: filterEnumValues(EVENT_TYPES, eventType),
+		organizerType: filterEnumValues(ORGANIZER_TYPES, organizerType),
+		skillLevel: filterEnumValues(SKILL_LEVELS, skillLevel),
+		format: filterEnumValues(FORMATS, format),
+		domain: filterEnumValues(DOMAINS, domain),
+		country: filterEnumValues(LATAM_COUNTRY_CODES, country),
+		department,
+		juniorFriendly,
+		mine,
+		timeFilter,
+	};
 
 	const clearAllFilters = () => {
 		setFilters({
@@ -78,18 +99,7 @@ export function EventsToolbar() {
 			<EventsFiltersPopover
 				open={filtersOpen}
 				onOpenChange={setFiltersOpen}
-				filters={{
-					eventType,
-					organizerType,
-					skillLevel,
-					format,
-					domain,
-					country,
-					department,
-					juniorFriendly,
-					mine,
-					timeFilter,
-				}}
+				filters={sanitizedFilters}
 				onFiltersChange={(updates) => setFilters(updates)}
 				onClearAll={clearAllFilters}
 			/>

--- a/components/god-mode/god-mode-event-form.tsx
+++ b/components/god-mode/god-mode-event-form.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { godModeCreateEvent } from "@/lib/actions/god-mode";
 import type { Organization } from "@/lib/db/schema";
+import { isEventType, isFormat, isSkillLevel } from "@/lib/db/schema/constants";
 
 const PERU_DEPARTMENTS = [
 	{ value: "Lima", label: "Lima" },
@@ -72,6 +73,26 @@ export function GodModeEventForm({ organizations }: GodModeEventFormProps) {
 		setError(null);
 
 		const formData = new FormData(e.currentTarget);
+		const rawEventType = formData.get("eventType");
+		const rawFormat = formData.get("format");
+		const rawSkillLevel = formData.get("skillLevel");
+		const rawPrizeCurrency = formData.get("prizeCurrency");
+		const eventType =
+			typeof rawEventType === "string" && isEventType(rawEventType)
+				? rawEventType
+				: undefined;
+		const format =
+			typeof rawFormat === "string" && isFormat(rawFormat)
+				? rawFormat
+				: "hybrid";
+		const skillLevel =
+			typeof rawSkillLevel === "string" && isSkillLevel(rawSkillLevel)
+				? rawSkillLevel
+				: "all";
+		const prizeCurrency =
+			rawPrizeCurrency === "PEN" || rawPrizeCurrency === "USD"
+				? rawPrizeCurrency
+				: "USD";
 
 		try {
 			if (!organizationId) {
@@ -84,14 +105,14 @@ export function GodModeEventForm({ organizations }: GodModeEventFormProps) {
 				name: formData.get("name") as string,
 				organizationId,
 				description: (formData.get("description") as string) || undefined,
-				eventType: (formData.get("eventType") as string) || undefined,
+				eventType,
 				startDate: formData.get("startDate")
 					? new Date(formData.get("startDate") as string)
 					: undefined,
 				endDate: formData.get("endDate")
 					? new Date(formData.get("endDate") as string)
 					: undefined,
-				format: (formData.get("format") as any) || "hybrid",
+				format,
 				country: (formData.get("country") as string) || undefined,
 				department: department || undefined,
 				city: (formData.get("city") as string) || undefined,
@@ -100,11 +121,11 @@ export function GodModeEventForm({ organizations }: GodModeEventFormProps) {
 				registrationUrl:
 					(formData.get("registrationUrl") as string) || undefined,
 				eventImageUrl: eventImageUrl || undefined,
-				skillLevel: (formData.get("skillLevel") as any) || "all",
+				skillLevel,
 				prizePool: formData.get("prizePool")
 					? Number(formData.get("prizePool"))
 					: undefined,
-				prizeCurrency: (formData.get("prizeCurrency") as any) || "USD",
+				prizeCurrency,
 				isApproved: true,
 			});
 

--- a/components/org/creation/org-event-form-minimal.tsx
+++ b/components/org/creation/org-event-form-minimal.tsx
@@ -61,7 +61,13 @@ import {
 } from "@/lib/actions/events";
 import { startLumaImport } from "@/lib/actions/import";
 import type { Event, Organization } from "@/lib/db/schema";
-import { EVENT_TYPES, SKILL_LEVELS } from "@/lib/db/schema/constants";
+import {
+	type EventType,
+	type Format,
+	isEventType,
+	isSkillLevel,
+	type SkillLevel,
+} from "@/lib/db/schema/constants";
 import {
 	EVENT_TYPE_LIST,
 	getEventTypeConfig,
@@ -73,21 +79,17 @@ import type { eventImportTask } from "@/trigger/event-import";
 import { AIExtractModal } from "./ai-extract-modal";
 import { ImproveDescriptionModal } from "./improve-description-modal";
 
-type EventType = (typeof EVENT_TYPES)[number];
-type SkillLevel = (typeof SKILL_LEVELS)[number];
 type ImportMetadata = ExtractedEventData & {
 	eventImageUrl?: string;
 	error?: string;
 	step?: string;
 };
 
-function isEventType(value: string): value is EventType {
-	return (EVENT_TYPES as readonly string[]).includes(value);
-}
-
-function isSkillLevel(value: string): value is SkillLevel {
-	return (SKILL_LEVELS as readonly string[]).includes(value);
-}
+const LOCATION_FORMATS = [
+	"in-person",
+	"virtual",
+	"hybrid",
+] as const satisfies readonly Format[];
 
 interface OrganizationWithRole {
 	organization: Organization;
@@ -148,9 +150,7 @@ export function OrgEventFormMinimal({
 	const [startTime, setStartTime] = useState(initialStart.time);
 	const [endDate, setEndDate] = useState(initialEnd.date);
 	const [endTime, setEndTime] = useState(initialEnd.time);
-	const [format, setFormat] = useState<"virtual" | "in-person" | "hybrid">(
-		(event?.format as "virtual" | "in-person" | "hybrid") || "in-person",
-	);
+	const [format, setFormat] = useState<Format>(event?.format || "in-person");
 	const [department, setDepartment] = useState(event?.department || "");
 	const [city, setCity] = useState(event?.city || "");
 	const [venue, setVenue] = useState(event?.venue || "");
@@ -981,11 +981,11 @@ export function OrgEventFormMinimal({
 								<div>
 									<Label className="text-sm mb-2 block">Formato</Label>
 									<div className="flex gap-2">
-										{["in-person", "virtual", "hybrid"].map((f) => (
+										{LOCATION_FORMATS.map((f) => (
 											<button
 												key={f}
 												type="button"
-												onClick={() => setFormat(f as any)}
+												onClick={() => setFormat(f)}
 												className={`flex-1 px-3 py-2 rounded-md text-sm transition-colors ${
 													format === f
 														? "bg-foreground text-background"

--- a/components/org/discovery/org-active-filters.tsx
+++ b/components/org/discovery/org-active-filters.tsx
@@ -3,7 +3,11 @@
 import { X } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
-import { LATAM_COUNTRIES, ORGANIZER_TYPE_LABELS } from "@/lib/db/schema";
+import {
+	isOrganizerType,
+	LATAM_COUNTRIES,
+	ORGANIZER_TYPE_LABELS,
+} from "@/lib/db/schema";
 
 const SIZE_LABELS: Record<string, string> = {
 	small: "< 100 miembros",
@@ -66,13 +70,15 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 		const countries = searchParams.get("countries");
 		if (countries) {
 			for (const code of countries.split(",")) {
-				const name = countryMap[code] || code;
-				filters.push({
-					key: `country-${code}`,
-					param: "countries",
-					value: code,
-					label: name,
-				});
+				const name = countryMap[code];
+				if (name) {
+					filters.push({
+						key: `country-${code}`,
+						param: "countries",
+						value: code,
+						label: name,
+					});
+				}
 			}
 		}
 
@@ -80,15 +86,14 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 		const types = searchParams.get("types");
 		if (types) {
 			for (const type of types.split(",")) {
-				const label =
-					ORGANIZER_TYPE_LABELS[type as keyof typeof ORGANIZER_TYPE_LABELS] ||
-					type;
-				filters.push({
-					key: `type-${type}`,
-					param: "types",
-					value: type,
-					label,
-				});
+				if (isOrganizerType(type)) {
+					filters.push({
+						key: `type-${type}`,
+						param: "types",
+						value: type,
+						label: ORGANIZER_TYPE_LABELS[type],
+					});
+				}
 			}
 		}
 

--- a/components/org/settings/org-settings-form.tsx
+++ b/components/org/settings/org-settings-form.tsx
@@ -48,7 +48,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { updateOrganizationById } from "@/lib/actions/organizations";
 import type { Organization } from "@/lib/db/schema";
-import { ORGANIZER_TYPES, type OrganizerType } from "@/lib/db/schema/constants";
+import { isOrganizerType, type OrganizerType } from "@/lib/db/schema/constants";
 import {
 	getOrganizerTypeConfig,
 	ORGANIZER_TYPE_LIST,
@@ -56,10 +56,6 @@ import {
 
 interface OrgSettingsFormProps {
 	organization: Organization;
-}
-
-function isOrganizerType(value: string): value is OrganizerType {
-	return (ORGANIZER_TYPES as readonly string[]).includes(value);
 }
 
 export function OrgSettingsForm({ organization }: OrgSettingsFormProps) {
@@ -119,7 +115,7 @@ export function OrgSettingsForm({ organization }: OrgSettingsFormProps) {
 			await updateOrganizationById(organization.id, {
 				name,
 				description: description || undefined,
-				type: type as any,
+				type,
 				websiteUrl: websiteUrl || undefined,
 				logoUrl: logoUrl || undefined,
 				coverUrl: coverUrl || undefined,

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -10,6 +10,7 @@ import {
 	inArray,
 	isNull,
 	or,
+	type SQL,
 	sql,
 } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
@@ -27,6 +28,24 @@ import {
 	type Organization,
 	organizations,
 } from "@/lib/db/schema";
+import {
+	DOMAINS,
+	EVENT_TYPES,
+	type EventType,
+	FORMATS,
+	type Format,
+	filterEnumValues,
+	isEventType,
+	isFormat,
+	isSkillLevel,
+	isStatus,
+	LATAM_COUNTRY_CODES,
+	ORGANIZER_TYPES,
+	SKILL_LEVELS,
+	type SkillLevel,
+	STATUSES,
+	type Status,
+} from "@/lib/db/schema/constants";
 import { type EventCategory, getCategoryById } from "@/lib/event-categories";
 import { isGodMode } from "@/lib/god-mode";
 import { createUniqueSlug, ensureUniqueShortCode } from "@/lib/slug-utils";
@@ -36,13 +55,13 @@ import { canManageEventById } from "./permissions";
 export interface EventFilters {
 	category?: EventCategory;
 	search?: string;
-	eventType?: string[];
-	organizerType?: string[];
-	skillLevel?: string[];
-	format?: string[];
-	status?: string[];
-	domain?: string[];
-	country?: string[];
+	eventType?: readonly string[];
+	organizerType?: readonly string[];
+	skillLevel?: readonly string[];
+	format?: readonly string[];
+	status?: readonly string[];
+	domain?: readonly string[];
+	country?: readonly string[];
 	department?: string[];
 	juniorFriendly?: boolean;
 	mine?: boolean;
@@ -91,7 +110,14 @@ export async function getEvents(
 		timeFilter = "upcoming",
 	} = filters;
 
-	const conditions: ReturnType<typeof eq>[] = [];
+	const eventTypes = filterEnumValues(EVENT_TYPES, eventType);
+	const organizerTypes = filterEnumValues(ORGANIZER_TYPES, organizerType);
+	const skillLevels = filterEnumValues(SKILL_LEVELS, skillLevel);
+	const formats = filterEnumValues(FORMATS, format);
+	const statuses = filterEnumValues(STATUSES, status);
+	const domains = filterEnumValues(DOMAINS, domain);
+	const countries = filterEnumValues(LATAM_COUNTRY_CODES, country);
+	const conditions: SQL[] = [];
 
 	// If mine=true, filter by user's communities
 	if (mine) {
@@ -149,23 +175,15 @@ export async function getEvents(
 	// Category filter - filter by event types in category (skip if "all" or no eventTypes)
 	const categoryConfig = getCategoryById(category);
 	if (categoryConfig && categoryConfig.eventTypes !== null) {
-		conditions.push(
-			inArray(events.eventType, categoryConfig.eventTypes as any),
-		);
+		conditions.push(inArray(events.eventType, categoryConfig.eventTypes));
 	}
 
-	// Event type filter (within category)
-	if (eventType && eventType.length > 0) {
-		conditions.push(
-			or(...eventType.map((t) => eq(events.eventType, t as any)))!,
-		);
+	if (eventTypes.length > 0) {
+		conditions.push(inArray(events.eventType, eventTypes));
 	}
 
-	// Organizer type filter
-	if (organizerType && organizerType.length > 0) {
-		conditions.push(
-			or(...organizerType.map((t) => eq(organizations.type, t as any)))!,
-		);
+	if (organizerTypes.length > 0) {
+		conditions.push(inArray(organizations.type, organizerTypes));
 	}
 
 	// Junior friendly filter (derived from skillLevel: beginner or all)
@@ -187,33 +205,16 @@ export async function getEvents(
 	}
 
 	// Skill level filter
-	if (skillLevel && skillLevel.length > 0) {
-		conditions.push(
-			or(
-				...skillLevel.map((level) =>
-					eq(
-						events.skillLevel,
-						level as "beginner" | "intermediate" | "advanced" | "all",
-					),
-				),
-			)!,
-		);
+	if (skillLevels.length > 0) {
+		conditions.push(inArray(events.skillLevel, skillLevels));
 	}
 
-	// Format filter
-	if (format && format.length > 0) {
-		conditions.push(
-			or(
-				...format.map((f) =>
-					eq(events.format, f as "virtual" | "in-person" | "hybrid"),
-				),
-			)!,
-		);
+	if (formats.length > 0) {
+		conditions.push(inArray(events.format, formats));
 	}
 
-	// Status filter - calculated dynamically based on dates
-	if (status && status.length > 0) {
-		const statusConditions = status.map((s) => {
+	if (statuses.length > 0) {
+		const statusConditions = statuses.map((s) => {
 			switch (s) {
 				case "ended":
 					// Event has ended (endDate < now)
@@ -235,15 +236,15 @@ export async function getEvents(
 	}
 
 	// Domain filter (uses array contains)
-	if (domain && domain.length > 0) {
+	if (domains.length > 0) {
 		conditions.push(
-			or(...domain.map((d) => sql`${d} = ANY(${events.domains})`))!,
+			or(...domains.map((d) => sql`${d} = ANY(${events.domains})`))!,
 		);
 	}
 
 	// Country filter
-	if (country && country.length > 0) {
-		conditions.push(or(...country.map((c) => eq(events.country, c)))!);
+	if (countries.length > 0) {
+		conditions.push(inArray(events.country, countries));
 	}
 
 	// Department filter
@@ -492,9 +493,9 @@ export interface CreateEventInput {
 	name: string;
 	description?: string;
 	websiteUrl?: string;
-	eventType?: string;
-	format?: string;
-	skillLevel?: string;
+	eventType?: EventType;
+	format?: Format;
+	skillLevel?: SkillLevel;
 	country?: string;
 	department?: string;
 	city?: string;
@@ -527,7 +528,7 @@ export interface UpdateEventInput {
 	startDate?: Date | null;
 	endDate?: Date | null;
 	registrationDeadline?: Date | null;
-	format?: "virtual" | "in-person" | "hybrid";
+	format?: Format;
 	department?: string;
 	city?: string;
 	venue?: string;
@@ -541,9 +542,9 @@ export interface UpdateEventInput {
 	websiteUrl?: string;
 	registrationUrl?: string;
 	eventImageUrl?: string;
-	eventType?: string;
-	skillLevel?: string;
-	status?: string;
+	eventType?: EventType;
+	skillLevel?: SkillLevel;
+	status?: Status;
 }
 
 export async function updateEvent(input: UpdateEventInput) {
@@ -562,9 +563,29 @@ export async function updateEvent(input: UpdateEventInput) {
 		};
 	}
 
-	const { eventId, ...updateData } = input;
+	const { eventId, eventType, format, skillLevel, status, ...updateData } =
+		input;
+	if (eventType !== undefined && !isEventType(eventType)) {
+		return { success: false, error: "Tipo de evento inválido" };
+	}
+	if (format !== undefined && !isFormat(format)) {
+		return { success: false, error: "Formato inválido" };
+	}
+	if (skillLevel !== undefined && !isSkillLevel(skillLevel)) {
+		return { success: false, error: "Nivel inválido" };
+	}
+	if (status !== undefined && !isStatus(status)) {
+		return { success: false, error: "Estado inválido" };
+	}
+	const typedUpdateData = {
+		...updateData,
+		...(eventType !== undefined ? { eventType } : {}),
+		...(format !== undefined ? { format } : {}),
+		...(skillLevel !== undefined ? { skillLevel } : {}),
+		...(status !== undefined ? { status } : {}),
+	};
 	const filteredData = Object.fromEntries(
-		Object.entries(updateData).filter(([, value]) => value !== undefined),
+		Object.entries(typedUpdateData).filter(([, value]) => value !== undefined),
 	);
 
 	if (Object.keys(filteredData).length === 0) {
@@ -637,9 +658,9 @@ export async function createEvent(
 				input.registrationUrl ||
 				`https://hack0.dev/e/${shortCode}`,
 			registrationUrl: input.registrationUrl || input.websiteUrl,
-			eventType: (input.eventType as any) || "hackathon",
-			format: (input.format as any) || "virtual",
-			skillLevel: (input.skillLevel as any) || "all",
+			eventType: input.eventType || "hackathon",
+			format: input.format || "virtual",
+			skillLevel: input.skillLevel || "all",
 			country: input.country || "PE",
 			department: input.department,
 			city: input.city,
@@ -654,7 +675,7 @@ export async function createEvent(
 				? new Date(input.registrationDeadline)
 				: undefined,
 			prizePool: input.prizePool,
-			prizeCurrency: (input.prizeCurrency as any) || "USD",
+			prizeCurrency: input.prizeCurrency || "USD",
 			eventImageUrl: input.eventImageUrl,
 			status: "upcoming",
 			isApproved,

--- a/lib/actions/god-mode.ts
+++ b/lib/actions/god-mode.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { db } from "@/lib/db";
 import { events } from "@/lib/db/schema";
+import type { EventType, Format, SkillLevel } from "@/lib/db/schema/constants";
 import { requireGodMode } from "@/lib/god-mode";
 import { createUniqueSlug, ensureUniqueShortCode } from "@/lib/slug-utils";
 
@@ -10,10 +11,10 @@ export async function godModeCreateEvent(data: {
 	name: string;
 	organizationId: string;
 	description?: string;
-	eventType?: string;
+	eventType?: EventType;
 	startDate?: Date;
 	endDate?: Date;
-	format?: "virtual" | "in-person" | "hybrid";
+	format?: Format;
 	country?: string;
 	department?: string;
 	city?: string;
@@ -21,7 +22,7 @@ export async function godModeCreateEvent(data: {
 	websiteUrl?: string;
 	registrationUrl?: string;
 	eventImageUrl?: string;
-	skillLevel?: "beginner" | "intermediate" | "advanced" | "all";
+	skillLevel?: SkillLevel;
 	prizePool?: number;
 	prizeCurrency?: "USD" | "PEN";
 	isApproved?: boolean;
@@ -38,7 +39,7 @@ export async function godModeCreateEvent(data: {
 			shortCode,
 			name: data.name,
 			description: data.description || null,
-			eventType: (data.eventType as any) || "hackathon",
+			eventType: data.eventType || "hackathon",
 			startDate: data.startDate || null,
 			endDate: data.endDate || null,
 			format: data.format || "hybrid",

--- a/lib/actions/organizations.ts
+++ b/lib/actions/organizations.ts
@@ -2,7 +2,7 @@
 
 import { auth } from "@clerk/nextjs/server";
 import { tasks } from "@trigger.dev/sdk/v3";
-import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, or, type SQL, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "@/lib/db";
 import {
@@ -11,6 +11,7 @@ import {
 	type NewOrganization,
 	organizations,
 } from "@/lib/db/schema";
+import { filterEnumValues, ORGANIZER_TYPES } from "@/lib/db/schema/constants";
 import { ensureUniqueOrgShortCode } from "@/lib/slug-utils";
 
 // ============================================
@@ -149,7 +150,7 @@ export interface OrganizationsResult {
 
 export interface OrganizationFilters {
 	search?: string;
-	type?: string[];
+	type?: readonly string[];
 	page?: number;
 	limit?: number;
 }
@@ -159,7 +160,8 @@ export async function getPublicOrganizations(
 ): Promise<OrganizationsResult> {
 	const { search, type, page = 1, limit = 12 } = filters;
 
-	const conditions: ReturnType<typeof eq>[] = [];
+	const organizerTypes = filterEnumValues(ORGANIZER_TYPES, type);
+	const conditions: SQL[] = [];
 
 	conditions.push(eq(organizations.isPublic, true));
 	conditions.push(eq(organizations.isPersonalOrg, false));
@@ -174,8 +176,8 @@ export async function getPublicOrganizations(
 		);
 	}
 
-	if (type && type.length > 0) {
-		conditions.push(or(...type.map((t) => eq(organizations.type, t as any)))!);
+	if (organizerTypes.length > 0) {
+		conditions.push(inArray(organizations.type, organizerTypes));
 	}
 
 	const whereClause = conditions.length > 0 ? and(...conditions) : undefined;

--- a/lib/db/schema/constants.ts
+++ b/lib/db/schema/constants.ts
@@ -29,6 +29,8 @@ export const EVENT_TYPES = [
 	"call_for_papers",
 ] as const;
 
+export type EventType = (typeof EVENT_TYPES)[number];
+
 export const EVENT_TYPE_LABELS: Record<string, string> = {
 	hackathon: "Hackathon",
 	conference: "Congreso",
@@ -208,6 +210,10 @@ export const SKILL_LEVELS = [
 export const FORMATS = ["virtual", "in-person", "hybrid"] as const;
 export const STATUSES = ["upcoming", "open", "ongoing", "ended"] as const;
 
+export type SkillLevel = (typeof SKILL_LEVELS)[number];
+export type Format = (typeof FORMATS)[number];
+export type Status = (typeof STATUSES)[number];
+
 export const DOMAINS = [
 	"ai",
 	"web3",
@@ -233,6 +239,8 @@ export const DOMAINS = [
 	"energy",
 	"general",
 ] as const;
+
+export type Domain = (typeof DOMAINS)[number];
 
 export const DOMAIN_LABELS: Record<string, string> = {
 	ai: "IA / Machine Learning",
@@ -260,6 +268,54 @@ export const DOMAIN_LABELS: Record<string, string> = {
 	general: "General",
 };
 
+export function isEnumValue<const T extends readonly string[]>(
+	values: T,
+	value: string | null | undefined,
+): value is T[number] {
+	return typeof value === "string" && values.includes(value);
+}
+
+export function filterEnumValues<const T extends readonly string[]>(
+	values: T,
+	input: readonly string[] | null | undefined,
+): T[number][] {
+	return Array.from(
+		new Set(
+			input?.filter((value): value is T[number] => isEnumValue(values, value)),
+		),
+	);
+}
+
+export function isEventType(
+	value: string | null | undefined,
+): value is EventType {
+	return isEnumValue(EVENT_TYPES, value);
+}
+
+export function isOrganizerType(
+	value: string | null | undefined,
+): value is OrganizerType {
+	return isEnumValue(ORGANIZER_TYPES, value);
+}
+
+export function isSkillLevel(
+	value: string | null | undefined,
+): value is SkillLevel {
+	return isEnumValue(SKILL_LEVELS, value);
+}
+
+export function isFormat(value: string | null | undefined): value is Format {
+	return isEnumValue(FORMATS, value);
+}
+
+export function isStatus(value: string | null | undefined): value is Status {
+	return isEnumValue(STATUSES, value);
+}
+
+export function isDomain(value: string | null | undefined): value is Domain {
+	return isEnumValue(DOMAINS, value);
+}
+
 export const LATAM_COUNTRIES = [
 	{ code: "AR", name: "Argentina" },
 	{ code: "BO", name: "Bolivia" },
@@ -283,6 +339,18 @@ export const LATAM_COUNTRIES = [
 	{ code: "VE", name: "Venezuela" },
 	{ code: "GLOBAL", name: "Global" },
 ] as const;
+
+export type CountryCode = (typeof LATAM_COUNTRIES)[number]["code"];
+
+export const LATAM_COUNTRY_CODES = LATAM_COUNTRIES.map(
+	(country) => country.code,
+) as readonly CountryCode[];
+
+export function isCountryCode(
+	value: string | null | undefined,
+): value is CountryCode {
+	return isEnumValue(LATAM_COUNTRY_CODES, value);
+}
 
 export const RELATIONSHIP_TYPES = [
 	"partner",

--- a/lib/event-categories.ts
+++ b/lib/event-categories.ts
@@ -1,4 +1,4 @@
-// Event categories - groups of event types with specific display configurations
+import type { EventType } from "@/lib/db/schema/constants";
 
 export type EventCategory = "all" | "competitions" | "learning" | "community";
 
@@ -6,8 +6,7 @@ export interface EventCategoryConfig {
 	id: EventCategory;
 	label: string;
 	description: string;
-	eventTypes: string[] | null; // null means all types
-	// Columns to show in table
+	eventTypes: EventType[] | null;
 	showPrize: boolean;
 	showFormat: boolean;
 	showSkillLevel: boolean;
@@ -18,7 +17,7 @@ export const EVENT_CATEGORIES: EventCategoryConfig[] = [
 		id: "all",
 		label: "Todos",
 		description: "Todos los eventos",
-		eventTypes: null, // No filter - show all
+		eventTypes: null,
 		showPrize: true,
 		showFormat: true,
 		showSkillLevel: false,
@@ -75,7 +74,7 @@ export function getCategoryById(
 }
 
 export function getCategoryByEventType(
-	eventType: string,
+	eventType: EventType,
 ): EventCategoryConfig | undefined {
 	return EVENT_CATEGORIES.find((cat) => cat.eventTypes?.includes(eventType));
 }

--- a/lib/event-utils.ts
+++ b/lib/event-utils.ts
@@ -8,10 +8,12 @@ export const DEFAULT_TIMEZONE = PERU_TIMEZONE;
 import {
 	DOMAIN_LABELS,
 	EVENT_TYPE_LABELS,
-	FORMATS,
+	type Format,
+	isFormat,
+	isSkillLevel,
 	ORGANIZER_TYPE_LABELS,
-	SKILL_LEVELS,
-	type STATUSES,
+	type SkillLevel,
+	type Status,
 } from "@/lib/db/schema";
 
 // =============================================================================
@@ -70,35 +72,25 @@ export function getEventStatus(event: {
 // LABELS
 // =============================================================================
 
-const FORMAT_LABELS: Record<(typeof FORMATS)[number], string> = {
+const FORMAT_LABELS: Record<Format, string> = {
 	virtual: "Virtual",
 	"in-person": "Presencial",
 	hybrid: "Híbrido",
 };
 
-const SKILL_LEVEL_LABELS: Record<(typeof SKILL_LEVELS)[number], string> = {
+const SKILL_LEVEL_LABELS: Record<SkillLevel, string> = {
 	beginner: "Principiante",
 	intermediate: "Intermedio",
 	advanced: "Avanzado",
 	all: "Todos los niveles",
 };
 
-const STATUS_LABELS: Record<(typeof STATUSES)[number], string> = {
+const STATUS_LABELS: Record<Status, string> = {
 	upcoming: "Próximamente",
 	open: "Abierto",
 	ongoing: "En curso",
 	ended: "Terminado",
 };
-
-function isFormat(value: string | null): value is (typeof FORMATS)[number] {
-	return !!value && (FORMATS as readonly string[]).includes(value);
-}
-
-function isSkillLevel(
-	value: string | null,
-): value is (typeof SKILL_LEVELS)[number] {
-	return !!value && (SKILL_LEVELS as readonly string[]).includes(value);
-}
 
 function isValidField(v: string | null | undefined): v is string {
 	return !!v && v !== "N/A" && v !== "n/a";


### PR DESCRIPTION
## Summary
- Centralize enum guards for event, organizer, skill, format, status, domain, and country filters
- Sanitize public event/community filters before they reach Drizzle enum comparisons
- Align visible filter state with the sanitized query state so invalid URL params do not appear as active filters
- Mark data-backed public pages as dynamic so deploy builds do not depend on live Neon reads during prerender

## Verification
- `bunx biome check --write ...`
- `bun --bun tsc --noEmit --pretty false`
- `bun run build`
- `git diff --check`
- `curl /events?...invalid filters` returns 200
- `curl /c/discover?...invalid filters` returns 200
- agent-browser: invalid events URL renders with `Filtros 2`
- agent-browser: invalid communities URL renders without `bad_type` active filter