### PR TITLE
fix: align community directory filters

### DIFF
--- a/app/(app)/api/organizations/route.ts
+++ b/app/(app)/api/organizations/route.ts
@@ -1,61 +1,58 @@
 import { auth } from "@clerk/nextjs/server";
-import { and, asc, count, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { normalizeCommunityDirectoryFilters } from "@/lib/community-directory-filters";
+import { getCommunityDirectoryConditions } from "@/lib/community-directory-query";
 import { db } from "@/lib/db";
 import { communityMembers, organizations } from "@/lib/db/schema";
-import { isOrganizerType } from "@/lib/db/schema/constants";
 
 const DEFAULT_LIMIT = 12;
 const MAX_LIMIT = 50;
 
 type OrderBy = "popular" | "recent" | "name" | "contact" | "contact_asc";
+const ORDER_BY_VALUES = [
+	"popular",
+	"recent",
+	"name",
+	"contact",
+	"contact_asc",
+] as const;
+
+function isOrderBy(value: string | null): value is OrderBy {
+	return ORDER_BY_VALUES.includes(value as OrderBy);
+}
+
+function parseIntegerParam(value: string | null, fallback: number) {
+	const parsed = Number.parseInt(value || "", 10);
+	return Number.isFinite(parsed) ? parsed : fallback;
+}
 
 export async function GET(request: NextRequest) {
 	try {
 		const { userId } = await auth();
 		const { searchParams } = new URL(request.url);
 
-		const search = searchParams.get("search") || undefined;
-		const rawType = searchParams.get("type");
-		const type = rawType && isOrganizerType(rawType) ? rawType : undefined;
-		const verifiedOnly = searchParams.get("verified") === "true";
-		const orderBy = (searchParams.get("orderBy") as OrderBy) || "popular";
+		const filters = normalizeCommunityDirectoryFilters({
+			search: searchParams.get("search"),
+			type: searchParams.get("type"),
+			types: searchParams.get("types"),
+			countries: searchParams.get("countries"),
+			sizes: searchParams.get("sizes"),
+			verification: searchParams.get("verification"),
+			verified: searchParams.get("verified"),
+			tags: searchParams.get("tags"),
+		});
+		const rawOrderBy = searchParams.get("orderBy");
+		const orderBy = isOrderBy(rawOrderBy) ? rawOrderBy : "popular";
 		const limit = Math.min(
-			Number.parseInt(searchParams.get("limit") || String(DEFAULT_LIMIT), 10),
+			Math.max(parseIntegerParam(searchParams.get("limit"), DEFAULT_LIMIT), 1),
 			MAX_LIMIT,
 		);
-		const offset = Number.parseInt(searchParams.get("offset") || "0", 10);
+		const offset = Math.max(
+			parseIntegerParam(searchParams.get("offset"), 0),
+			0,
+		);
 
-		const conditions = [
-			eq(organizations.isPublic, true),
-			eq(organizations.isPersonalOrg, false),
-		];
-
-		if (search) {
-			conditions.push(
-				or(
-					ilike(organizations.name, `%${search}%`),
-					ilike(organizations.displayName, `%${search}%`),
-					ilike(organizations.description, `%${search}%`),
-				)!,
-			);
-		}
-
-		if (type) {
-			conditions.push(eq(organizations.type, type));
-		}
-
-		if (verifiedOnly) {
-			conditions.push(eq(organizations.isVerified, true));
-		}
-
-		// Get total count for pagination
-		const [{ total }] = await db
-			.select({ total: count() })
-			.from(organizations)
-			.where(and(...conditions));
-
-		// Subquery for member count
 		const memberCountSubquery = db
 			.select({
 				communityId: communityMembers.communityId,
@@ -64,8 +61,19 @@ export async function GET(request: NextRequest) {
 			.from(communityMembers)
 			.groupBy(communityMembers.communityId)
 			.as("member_counts");
+		const memberCountSql = sql<number>`COALESCE(${memberCountSubquery.memberCount}, 0)`;
 
-		// Build query with member count
+		const conditions = getCommunityDirectoryConditions(filters, memberCountSql);
+
+		const [{ total }] = await db
+			.select({ total: count() })
+			.from(organizations)
+			.leftJoin(
+				memberCountSubquery,
+				eq(organizations.id, memberCountSubquery.communityId),
+			)
+			.where(and(...conditions));
+
 		let query = db
 			.select({
 				id: organizations.id,
@@ -78,10 +86,7 @@ export async function GET(request: NextRequest) {
 				coverUrl: organizations.coverUrl,
 				isVerified: organizations.isVerified,
 				createdAt: organizations.createdAt,
-				memberCount:
-					sql<number>`COALESCE(${memberCountSubquery.memberCount}, 0)`.as(
-						"member_count",
-					),
+				memberCount: memberCountSql.as("member_count"),
 				email: organizations.email,
 				country: organizations.country,
 				department: organizations.department,
@@ -108,11 +113,8 @@ export async function GET(request: NextRequest) {
 			CASE WHEN ${organizations.githubUrl} IS NOT NULL THEN 1 ELSE 0 END
 		)`;
 
-		// Apply ordering
 		if (orderBy === "popular") {
-			query = query.orderBy(
-				desc(sql`COALESCE(${memberCountSubquery.memberCount}, 0)`),
-			);
+			query = query.orderBy(desc(memberCountSql));
 		} else if (orderBy === "recent") {
 			query = query.orderBy(desc(organizations.createdAt));
 		} else if (orderBy === "name") {

--- a/app/(app)/c/discover/page.tsx
+++ b/app/(app)/c/discover/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { and, count, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { and, count, desc, eq, sql } from "drizzle-orm";
 import { LayoutGrid, List } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
@@ -20,9 +20,10 @@ import {
 	getUniqueDepartments,
 	getUniqueTags,
 } from "@/lib/actions/communities";
+import { normalizeCommunityDirectoryFilters } from "@/lib/community-directory-filters";
+import { getCommunityDirectoryConditions } from "@/lib/community-directory-query";
 import { db } from "@/lib/db";
 import { communityMembers, organizations } from "@/lib/db/schema";
-import { isCountryCode, isOrganizerType } from "@/lib/db/schema/constants";
 import { getCommunitiesViewPreference } from "@/lib/view-preferences";
 
 interface DiscoverPageProps {
@@ -63,53 +64,7 @@ async function getInitialCommunities(
 	},
 	userId: string | null,
 ): Promise<CommunitiesResponse> {
-	const search = params.search;
-	const type =
-		params.type && isOrganizerType(params.type) ? params.type : undefined;
-	const typesArray = params.types?.split(",").filter(isOrganizerType) || [];
-	const countriesArray =
-		params.countries?.split(",").filter(isCountryCode) || [];
-	const verifiedOnly = params.verified === "true";
-
-	const conditions = [
-		eq(organizations.isPublic, true),
-		eq(organizations.isPersonalOrg, false),
-	];
-
-	if (search) {
-		conditions.push(
-			or(
-				ilike(organizations.name, `%${search}%`),
-				ilike(organizations.displayName, `%${search}%`),
-				ilike(organizations.description, `%${search}%`),
-			)!,
-		);
-	}
-
-	if (type) {
-		conditions.push(eq(organizations.type, type));
-	}
-
-	if (typesArray.length > 0) {
-		conditions.push(or(...typesArray.map((t) => eq(organizations.type, t)))!);
-	}
-
-	if (countriesArray.length > 0) {
-		conditions.push(
-			or(
-				...countriesArray.map((country) => eq(organizations.country, country)),
-			)!,
-		);
-	}
-
-	if (verifiedOnly) {
-		conditions.push(eq(organizations.isVerified, true));
-	}
-
-	const [{ total }] = await db
-		.select({ total: count() })
-		.from(organizations)
-		.where(and(...conditions));
+	const filters = normalizeCommunityDirectoryFilters(params);
 
 	const memberCountSubquery = db
 		.select({
@@ -119,6 +74,18 @@ async function getInitialCommunities(
 		.from(communityMembers)
 		.groupBy(communityMembers.communityId)
 		.as("member_counts");
+	const memberCountSql = sql<number>`COALESCE(${memberCountSubquery.memberCount}, 0)`;
+
+	const conditions = getCommunityDirectoryConditions(filters, memberCountSql);
+
+	const [{ total }] = await db
+		.select({ total: count() })
+		.from(organizations)
+		.leftJoin(
+			memberCountSubquery,
+			eq(organizations.id, memberCountSubquery.communityId),
+		)
+		.where(and(...conditions));
 
 	const communities = await db
 		.select({
@@ -131,10 +98,7 @@ async function getInitialCommunities(
 			logoUrl: organizations.logoUrl,
 			coverUrl: organizations.coverUrl,
 			isVerified: organizations.isVerified,
-			memberCount:
-				sql<number>`COALESCE(${memberCountSubquery.memberCount}, 0)`.as(
-					"member_count",
-				),
+			memberCount: memberCountSql.as("member_count"),
 			email: organizations.email,
 			country: organizations.country,
 			department: organizations.department,
@@ -150,7 +114,7 @@ async function getInitialCommunities(
 			eq(organizations.id, memberCountSubquery.communityId),
 		)
 		.where(and(...conditions))
-		.orderBy(desc(sql`COALESCE(${memberCountSubquery.memberCount}, 0)`))
+		.orderBy(desc(memberCountSql))
 		.limit(INITIAL_LIMIT)
 		.offset(0);
 
@@ -200,13 +164,7 @@ export default async function DiscoverPage({
 	const { userId } = await auth();
 	const params = await searchParams;
 
-	const countriesArray =
-		params.countries?.split(",").filter(isCountryCode) || [];
-	const typesArray = params.types?.split(",").filter(Boolean) || [];
-	const sizesArray = params.sizes?.split(",").filter(Boolean) || [];
-	const verificationArray =
-		params.verification?.split(",").filter(Boolean) || [];
-	const tagsArray = params.tags?.split(",").filter(Boolean) || [];
+	const normalizedFilters = normalizeCommunityDirectoryFilters(params);
 
 	const [initialData, _departments, availableCountries, availableTags] =
 		await Promise.all([
@@ -251,11 +209,11 @@ export default async function DiscoverPage({
 					>
 						<OrgSidebarFilters
 							defaultSearch={params.search}
-							defaultCountries={countriesArray}
-							defaultTypes={typesArray}
-							defaultSizes={sizesArray}
-							defaultVerification={verificationArray}
-							defaultTags={tagsArray}
+							defaultCountries={normalizedFilters.countries}
+							defaultTypes={normalizedFilters.types}
+							defaultSizes={normalizedFilters.sizes}
+							defaultVerification={normalizedFilters.verification}
+							defaultTags={normalizedFilters.tags}
 							availableCountries={availableCountries}
 							availableTags={availableTags}
 						/>

--- a/components/org/discovery/org-active-filters.tsx
+++ b/components/org/discovery/org-active-filters.tsx
@@ -3,8 +3,9 @@
 import { X } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
+import { normalizeCommunityDirectoryFilters } from "@/lib/community-directory-filters";
 import {
-	isOrganizerType,
+	COMMUNITY_TAG_LABELS,
 	LATAM_COUNTRIES,
 	ORGANIZER_TYPE_LABELS,
 } from "@/lib/db/schema";
@@ -54,6 +55,16 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 
 	const activeFilters = useMemo(() => {
 		const filters: ActiveFilter[] = [];
+		const normalizedFilters = normalizeCommunityDirectoryFilters({
+			search: searchParams.get("search"),
+			type: searchParams.get("type"),
+			types: searchParams.get("types"),
+			countries: searchParams.get("countries"),
+			sizes: searchParams.get("sizes"),
+			verification: searchParams.get("verification"),
+			verified: searchParams.get("verified"),
+			tags: searchParams.get("tags"),
+		});
 
 		// Category
 		const category = searchParams.get("category");
@@ -67,9 +78,8 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 		}
 
 		// Countries
-		const countries = searchParams.get("countries");
-		if (countries) {
-			for (const code of countries.split(",")) {
+		if (normalizedFilters.countries.length > 0) {
+			for (const code of normalizedFilters.countries) {
 				const name = countryMap[code];
 				if (name) {
 					filters.push({
@@ -83,24 +93,19 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 		}
 
 		// Types
-		const types = searchParams.get("types");
-		if (types) {
-			for (const type of types.split(",")) {
-				if (isOrganizerType(type)) {
-					filters.push({
-						key: `type-${type}`,
-						param: "types",
-						value: type,
-						label: ORGANIZER_TYPE_LABELS[type],
-					});
-				}
+		if (normalizedFilters.types.length > 0) {
+			for (const type of normalizedFilters.types) {
+				filters.push({
+					key: `type-${type}`,
+					param: "types",
+					value: type,
+					label: ORGANIZER_TYPE_LABELS[type],
+				});
 			}
 		}
 
-		// Sizes
-		const sizes = searchParams.get("sizes");
-		if (sizes) {
-			for (const size of sizes.split(",")) {
+		if (normalizedFilters.sizes.length > 0) {
+			for (const size of normalizedFilters.sizes) {
 				const label = SIZE_LABELS[size] || size;
 				filters.push({
 					key: `size-${size}`,
@@ -111,10 +116,8 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 			}
 		}
 
-		// Verification
-		const verification = searchParams.get("verification");
-		if (verification) {
-			for (const v of verification.split(",")) {
+		if (normalizedFilters.verification.length > 0) {
+			for (const v of normalizedFilters.verification) {
 				const label = VERIFICATION_LABELS[v] || v;
 				filters.push({
 					key: `verification-${v}`,
@@ -125,7 +128,17 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 			}
 		}
 
-		// Search
+		if (normalizedFilters.tags.length > 0) {
+			for (const tag of normalizedFilters.tags) {
+				filters.push({
+					key: `tag-${tag}`,
+					param: "tags",
+					value: tag,
+					label: COMMUNITY_TAG_LABELS[tag],
+				});
+			}
+		}
+
 		const search = searchParams.get("search");
 		if (search) {
 			filters.push({
@@ -169,6 +182,7 @@ export function OrgActiveFilters({ totalResults }: OrgActiveFiltersProps) {
 		params.delete("types");
 		params.delete("sizes");
 		params.delete("verification");
+		params.delete("tags");
 		router.push(`${pathname}?${params.toString()}`);
 	};
 

--- a/components/org/discovery/orgs-grid.tsx
+++ b/components/org/discovery/orgs-grid.tsx
@@ -18,6 +18,7 @@ import {
 	useCommunities,
 } from "@/hooks/use-communities";
 import { followCommunity, unfollowCommunity } from "@/lib/actions/communities";
+import { normalizeCommunityDirectoryFilters } from "@/lib/community-directory-filters";
 import { ORGANIZER_TYPE_LABELS } from "@/lib/db/schema";
 
 function hashString(str: string): number {
@@ -311,9 +312,16 @@ function LoadingSkeleton() {
 export function OrgsGrid({ initialData, isAuthenticated }: OrgsGridProps) {
 	const searchParams = useSearchParams();
 
-	const search = searchParams.get("search") || undefined;
-	const type = searchParams.get("type") || undefined;
-	const verifiedOnly = searchParams.get("verified") === "true";
+	const filters = normalizeCommunityDirectoryFilters({
+		search: searchParams.get("search"),
+		type: searchParams.get("type"),
+		types: searchParams.get("types"),
+		countries: searchParams.get("countries"),
+		sizes: searchParams.get("sizes"),
+		verification: searchParams.get("verification"),
+		verified: searchParams.get("verified"),
+		tags: searchParams.get("tags"),
+	});
 
 	const {
 		data,
@@ -323,9 +331,12 @@ export function OrgsGrid({ initialData, isAuthenticated }: OrgsGridProps) {
 		isLoading,
 		isError,
 	} = useCommunities({
-		search,
-		type,
-		verifiedOnly,
+		search: filters.search,
+		types: filters.types,
+		countries: filters.countries,
+		sizes: filters.sizes,
+		verification: filters.verification,
+		tags: filters.tags,
 		initialData,
 	});
 

--- a/components/org/discovery/orgs-list.tsx
+++ b/components/org/discovery/orgs-list.tsx
@@ -26,6 +26,7 @@ import {
 	useCommunities,
 } from "@/hooks/use-communities";
 import { followCommunity, unfollowCommunity } from "@/lib/actions/communities";
+import { normalizeCommunityDirectoryFilters } from "@/lib/community-directory-filters";
 import { ORGANIZER_TYPE_LABELS } from "@/lib/db/schema";
 
 interface OrgsListProps {
@@ -34,6 +35,17 @@ interface OrgsListProps {
 }
 
 type SortColumn = "name" | "contact" | "members";
+const ORDER_BY_VALUES = [
+	"popular",
+	"recent",
+	"name",
+	"contact",
+	"contact_asc",
+] as const;
+
+function isOrderBy(value: string | null): value is OrderBy {
+	return ORDER_BY_VALUES.includes(value as OrderBy);
+}
 
 function getContactCount(community: PublicCommunity): number {
 	let count = 0;
@@ -335,10 +347,18 @@ export function OrgsList({ initialData, isAuthenticated }: OrgsListProps) {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 
-	const search = searchParams.get("search") || undefined;
-	const type = searchParams.get("type") || undefined;
-	const verifiedOnly = searchParams.get("verified") === "true";
-	const orderByParam = (searchParams.get("orderBy") as OrderBy) || "popular";
+	const filters = normalizeCommunityDirectoryFilters({
+		search: searchParams.get("search"),
+		type: searchParams.get("type"),
+		types: searchParams.get("types"),
+		countries: searchParams.get("countries"),
+		sizes: searchParams.get("sizes"),
+		verification: searchParams.get("verification"),
+		verified: searchParams.get("verified"),
+		tags: searchParams.get("tags"),
+	});
+	const rawOrderBy = searchParams.get("orderBy");
+	const orderByParam = isOrderBy(rawOrderBy) ? rawOrderBy : "popular";
 
 	const { column: sortColumn, direction: sortDirection } =
 		getOrderByFromParams(orderByParam);
@@ -352,9 +372,12 @@ export function OrgsList({ initialData, isAuthenticated }: OrgsListProps) {
 		isError,
 		refetch,
 	} = useCommunities({
-		search,
-		type,
-		verifiedOnly,
+		search: filters.search,
+		types: filters.types,
+		countries: filters.countries,
+		sizes: filters.sizes,
+		verification: filters.verification,
+		tags: filters.tags,
 		orderBy: orderByParam,
 		initialData: orderByParam === "popular" ? initialData : undefined,
 	});

--- a/hooks/use-communities.ts
+++ b/hooks/use-communities.ts
@@ -35,6 +35,11 @@ export type OrderBy = "popular" | "recent" | "name" | "contact" | "contact_asc";
 export interface UseCommunitiesParams {
 	search?: string;
 	type?: string;
+	types?: string[];
+	countries?: string[];
+	sizes?: string[];
+	verification?: string[];
+	tags?: string[];
 	verifiedOnly?: boolean;
 	orderBy?: OrderBy;
 	limit?: number;
@@ -44,6 +49,11 @@ export interface UseCommunitiesParams {
 export function useCommunities({
 	search,
 	type,
+	types = [],
+	countries = [],
+	sizes = [],
+	verification = [],
+	tags = [],
 	verifiedOnly,
 	orderBy = "popular",
 	limit = 12,
@@ -52,7 +62,18 @@ export function useCommunities({
 	const hasInitialData = initialData !== undefined;
 
 	return useInfiniteQuery({
-		queryKey: ["communities", search, type, verifiedOnly, orderBy],
+		queryKey: [
+			"communities",
+			search,
+			type,
+			types,
+			countries,
+			sizes,
+			verification,
+			tags,
+			verifiedOnly,
+			orderBy,
+		],
 		queryFn: async ({ pageParam = 0 }) => {
 			const params = new URLSearchParams({
 				limit: limit.toString(),
@@ -62,6 +83,13 @@ export function useCommunities({
 
 			if (search) params.set("search", search);
 			if (type) params.set("type", type);
+			if (types.length > 0) params.set("types", types.join(","));
+			if (countries.length > 0) params.set("countries", countries.join(","));
+			if (sizes.length > 0) params.set("sizes", sizes.join(","));
+			if (verification.length > 0) {
+				params.set("verification", verification.join(","));
+			}
+			if (tags.length > 0) params.set("tags", tags.join(","));
 			if (verifiedOnly) params.set("verified", "true");
 
 			const response = await fetch(`/api/organizations?${params}`);

--- a/lib/community-directory-filters.ts
+++ b/lib/community-directory-filters.ts
@@ -1,0 +1,73 @@
+import {
+	COMMUNITY_TAGS,
+	filterEnumValues,
+	LATAM_COUNTRY_CODES,
+	ORGANIZER_TYPES,
+} from "@/lib/db/schema/constants";
+
+export const COMMUNITY_SIZE_FILTERS = ["small", "medium", "large"] as const;
+export const COMMUNITY_VERIFICATION_FILTERS = [
+	"verified",
+	"unverified",
+] as const;
+
+export type CommunitySizeFilter = (typeof COMMUNITY_SIZE_FILTERS)[number];
+export type CommunityVerificationFilter =
+	(typeof COMMUNITY_VERIFICATION_FILTERS)[number];
+
+export interface CommunityDirectoryFilters {
+	search?: string;
+	countries: (typeof LATAM_COUNTRY_CODES)[number][];
+	types: (typeof ORGANIZER_TYPES)[number][];
+	sizes: CommunitySizeFilter[];
+	verification: CommunityVerificationFilter[];
+	tags: (typeof COMMUNITY_TAGS)[number][];
+}
+
+export interface CommunityDirectoryFilterInput {
+	search?: string | null;
+	countries?: string | null;
+	type?: string | null;
+	types?: string | null;
+	sizes?: string | null;
+	verification?: string | null;
+	verified?: string | null;
+	tags?: string | null;
+}
+
+export function splitFilterParam(value: string | null | undefined): string[] {
+	return (
+		value
+			?.split(",")
+			.map((item) => item.trim())
+			.filter(Boolean) ?? []
+	);
+}
+
+export function normalizeCommunityDirectoryFilters(
+	input: CommunityDirectoryFilterInput,
+): CommunityDirectoryFilters {
+	const typeValues = [
+		...splitFilterParam(input.type),
+		...splitFilterParam(input.types),
+	];
+	const verificationValues = splitFilterParam(input.verification);
+
+	return {
+		search: input.search?.trim() || undefined,
+		countries: filterEnumValues(
+			LATAM_COUNTRY_CODES,
+			splitFilterParam(input.countries),
+		),
+		types: filterEnumValues(ORGANIZER_TYPES, typeValues),
+		sizes: filterEnumValues(
+			COMMUNITY_SIZE_FILTERS,
+			splitFilterParam(input.sizes),
+		),
+		verification: filterEnumValues(COMMUNITY_VERIFICATION_FILTERS, [
+			...verificationValues,
+			...(input.verified === "true" ? ["verified"] : []),
+		]),
+		tags: filterEnumValues(COMMUNITY_TAGS, splitFilterParam(input.tags)),
+	};
+}

--- a/lib/community-directory-query.ts
+++ b/lib/community-directory-query.ts
@@ -1,0 +1,76 @@
+import { eq, ilike, inArray, or, type SQL, sql } from "drizzle-orm";
+import type {
+	CommunityDirectoryFilters,
+	CommunitySizeFilter,
+} from "@/lib/community-directory-filters";
+import { organizations } from "@/lib/db/schema";
+
+function getSizeCondition(
+	size: CommunitySizeFilter,
+	memberCountSql: SQL<number>,
+) {
+	if (size === "small") return sql`${memberCountSql} < 100`;
+	if (size === "medium") {
+		return sql`${memberCountSql} >= 100 AND ${memberCountSql} < 1000`;
+	}
+	return sql`${memberCountSql} >= 1000`;
+}
+
+export function getCommunityDirectoryConditions(
+	filters: CommunityDirectoryFilters,
+	memberCountSql: SQL<number>,
+) {
+	const conditions: SQL[] = [
+		eq(organizations.isPublic, true),
+		eq(organizations.isPersonalOrg, false),
+	];
+
+	if (filters.search) {
+		conditions.push(
+			or(
+				ilike(organizations.name, `%${filters.search}%`),
+				ilike(organizations.displayName, `%${filters.search}%`),
+				ilike(organizations.description, `%${filters.search}%`),
+			)!,
+		);
+	}
+
+	if (filters.types.length > 0) {
+		conditions.push(inArray(organizations.type, filters.types));
+	}
+
+	if (filters.countries.length > 0) {
+		conditions.push(inArray(organizations.country, filters.countries));
+	}
+
+	if (filters.tags.length > 0) {
+		conditions.push(
+			or(
+				...filters.tags.map((tag) => sql`${tag} = ANY(${organizations.tags})`),
+			)!,
+		);
+	}
+
+	if (filters.verification.length === 1) {
+		if (filters.verification[0] === "verified") {
+			conditions.push(eq(organizations.isVerified, true));
+		} else {
+			conditions.push(
+				or(
+					eq(organizations.isVerified, false),
+					sql`${organizations.isVerified} IS NULL`,
+				)!,
+			);
+		}
+	}
+
+	if (filters.sizes.length > 0) {
+		conditions.push(
+			or(
+				...filters.sizes.map((size) => getSizeCondition(size, memberCountSql)),
+			)!,
+		);
+	}
+
+	return conditions;
+}


### PR DESCRIPTION
## Summary
- Add a shared community-directory filter normalizer and SQL condition builder
- Apply countries, types, sizes, verification, and tags consistently in SSR and /api/organizations
- Pass the same filters through infinite-scroll queries for cards and table views
- Keep active filter chips sanitized and include tag chips

## Verification
- `bunx biome check --write ...`
- `bun --bun tsc --noEmit --pretty false`
- `bun run build`
- `git diff --check`
- API: invalid type is ignored while valid `community` filter returns only community rows
- API: `sizes=small` returns 42 PE community rows, `sizes=large` returns 0
- API: `verification=unverified` returns only false verified rows
- agent-browser: `/c/discover?countries=PE&types=community&sizes=large` renders 0 results with matching active filters