### PR TITLE
docs: refresh agent maps after cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,51 +4,59 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-hack0.dev is a hackathon and tech event discovery platform focused on Peru. It aggregates hackathons, conferences, workshops, and other innovation events. The app has a Vercel/Linear/Clerk-inspired grayscale aesthetic with a focus on UX/DX.
+hack0.dev is the public Peru Agentic Builder Index. It maps events, communities, hackathons, labs, grants, builders, demo projects, and useful AI workflows in Peru, with Luma imports as the primary event pipeline.
 
 ## Commands
 
 ```bash
 bun run dev          # Start Next.js dev server
 bun run build        # Production build
-bun run lint         # ESLint
+bun run check        # Biome check
 bun run db:push      # Push schema directly (dev)
+bun run db:migrate   # Apply Drizzle migrations
 bun run db:studio    # Open Drizzle Studio
-bun run scrape       # Scrape events from Devpost using Firecrawl
+bun run sync:luma    # Backfill/sync the Luma calendar
 ```
 
 ## Architecture
 
 ### Tech Stack
 
-- **Framework**: Next.js 15 with App Router (React 19)
+- **Framework**: Next.js 16 with App Router (React 19)
 - **Database**: Neon PostgreSQL with Drizzle ORM
 - **Auth**: Clerk (redirect mode, not modal)
 - **Email**: Resend for notifications
 - **UI**: shadcn/ui components with Tailwind CSS v4
 - **URL State**: nuqs for type-safe search params
-- **Background Jobs**: Trigger.dev v3
+- **Background Jobs**: Trigger.dev v4
 
 ### Key Directories
 
 - `app/` - Next.js App Router pages
-  - `page.tsx` - Main event listing with filters, categories, and load more
-  - `[slug]/page.tsx` - Event detail page with two-column layout
+  - `(landing)/page.tsx` - Peru Agentic Builder Index homepage
+  - `events/` - Public event listing
+  - `(app)/e/[code]/page.tsx` - Event detail page
+  - `(app)/c/` - Community and organization directory
+  - `(app)/onboarding/` - User onboarding
+  - `(admin)/god/` - Admin curation and ecosystem graph
   - `(auth)/` - Clerk auth pages (sign-in, sign-up with catch-all routes)
-  - `submit/` - Event submission form (grid layout)
-  - `api/subscribe`, `api/verify`, `api/unsubscribe` - Email subscription endpoints
+  - `api/` - Event, organization, webhook, upload, and user APIs
 - `components/`
-  - `events/` - Event-specific components (event-row-with-children, filter-bar, category-tabs)
+  - `events/` - Event views, toolbar, detail, and edit components
+  - `org/` - Organization discovery, creation, settings, members, and layout
+  - `god-mode/` - Admin graph, navigation, and creation tools
+  - `admin/scraper/` - Scraper curation UI
   - `layout/` - Shared layout components (site-header, site-footer)
   - `ui/` - shadcn/ui components
 - `lib/`
-  - `db/schema.ts` - Drizzle schema with events, subscriptions, claims, sponsors, organizations tables
+  - `db/schema/` - Drizzle schema modules for events, organizations, users, imports, staff, community, and relations
   - `actions/events.ts` - Server actions with smart ordering, child events, sponsors
+  - `actions/organizations.ts` - Organization directory and admin actions
+  - `community-directory-query.ts` - Shared public directory filtering
   - `event-utils.ts` - Date formatting, status helpers, label functions
   - `event-categories.ts` - Category definitions (competitions, learning, community)
-  - `email/` - Resend templates and notification logic
   - `scraper/` - Firecrawl-based scraper for Devpost
-- `trigger/` - Trigger.dev background tasks (luma-import, org-scraper, drift-check)
+- `trigger/` - Trigger.dev background tasks for imports, webhooks, and drift checks
 
 ### Data Model
 
@@ -59,13 +67,17 @@ bun run scrape       # Scrape events from Devpost using Firecrawl
 - `parentEventId` - For multi-day events or conference tracks (child events)
 - `prizeCurrency` - USD or PEN (soles)
 - `skillLevel` - beginner/intermediate/advanced/all
-- `isOrganizerVerified` - Verified organizer badge
+- `approvalStatus` and `isApproved` - Admin curation state
 
-**sponsors** - Event sponsors/partners with tier: platinum, gold, silver, bronze, partner, community
+**organizations** - Communities, startups, investors, labs, companies, universities, and other ecosystem actors.
 
-**organizerClaims** / **winnerClaims** - Verification requests with status: pending, approved, rejected
+**eventHostOrganizations** / **eventHosts** - Event hosts imported from Luma or assigned manually.
 
-**subscriptions** - Email notification subscriptions with verification tokens
+**eventSponsors** - Event sponsor and partner links to organizations.
+
+**users** / **emailVerifications** - Clerk-backed profiles and Luma email verification.
+
+**importJobs** / **scrapeSources** / **scrapeRuns** - Import and scraper operations.
 
 ### Event Categories
 
@@ -111,7 +123,7 @@ Required in `.env`:
 
 ---
 
-## Trigger.dev v3 Quick Reference
+## Trigger.dev Quick Reference
 
 **MUST use `@trigger.dev/sdk/v3`, NEVER `client.defineJob` (v2 deprecated)**
 

--- a/components/admin/AGENTS.md
+++ b/components/admin/AGENTS.md
@@ -7,7 +7,8 @@ Componentes para el panel de administración (God Mode).
 | Component | Description |
 |-----------|-------------|
 | pending-events-list.tsx | Lista de eventos pendientes de aprobación |
-| pending-org-events.tsx | Eventos pendientes por organización |
+| scraper/ | Inbox de curación para eventos importados/scrapeados |
+| scraper-constants.ts | Constantes visuales compartidas del scraper inbox |
 
 ## Patrones
 
@@ -18,4 +19,5 @@ Componentes para el panel de administración (God Mode).
 
 ## Dependencias
 
-- `@/lib/actions/pending-events` - Pending events actions
+- `@/lib/actions/events` - Approval actions para eventos
+- `@/lib/actions/scraper-curation` - Acciones de curación para imports scrapeados

--- a/components/god-mode/AGENTS.md
+++ b/components/god-mode/AGENTS.md
@@ -22,12 +22,11 @@ Interfaz de super-administrador para gestión global del ecosistema.
 | /god/events | Gestión de eventos |
 | /god/events/new | Crear evento |
 | /god/organizations | Gestión de orgs |
-| /god/pending | Aprobaciones pendientes |
 | /god/graph | Visualización de ecosistema |
 
 ## Acceso
 
-Solo usuarios con `role: "god"` en `userPreferences`.
+Solo usuarios cuyo email esté en `ADMIN_EMAILS`.
 
 Verificación en:
 - `lib/god-mode.ts` - Helper `isGodMode()`
@@ -36,5 +35,7 @@ Verificación en:
 ## Dependencias
 
 - `@/lib/actions/god-mode` - Acciones de admin
-- `@/lib/actions/pending-events` - Eventos pendientes
+- `@/lib/actions/events` - Approval actions para eventos
+- `@/lib/actions/organizations` - Verificación y gestión de orgs
+- `@/lib/actions/organization-relationships` - Datos del grafo
 - D3.js - Visualización de grafos

--- a/lib/actions/AGENTS.md
+++ b/lib/actions/AGENTS.md
@@ -17,9 +17,9 @@ Todas las server actions de la aplicación. Core de la lógica de negocio.
 | import.ts | Importación de eventos externos |
 | ai-extract.ts | Extracción de datos con IA |
 | god-mode.ts | Acciones de super-admin |
-| pending-events.ts | Eventos pendientes de aprobación |
 | event-organizers.ts | Gestión de organizadores |
 | organization-relationships.ts | Relaciones entre organizaciones |
+| scraper-curation.ts | Curación de eventos scrapeados |
 | users.ts | Gestión de usuarios |
 
 ## Patrones

--- a/lib/db/AGENTS.md
+++ b/lib/db/AGENTS.md
@@ -6,7 +6,7 @@ Schema Drizzle ORM y queries para Neon PostgreSQL.
 
 | Archivo | Propósito |
 |---------|-----------|
-| schema.ts | Definición completa del schema (~50KB) |
+| schema/ | Schema modular por dominio |
 | index.ts | Conexión y exportación de `db` |
 | seed.ts | Script de seeding (~36KB) |
 | queries/ | Query helpers reutilizables |
@@ -17,13 +17,19 @@ Schema Drizzle ORM y queries para Neon PostgreSQL.
 |-------|-----------|
 | events | Eventos (hackathons, workshops, etc.) |
 | organizations | Comunidades/organizadores |
-| userPreferences | Preferencias y rol de usuario |
+| users | Perfiles Clerk y preferencias públicas |
+| emailVerifications | Verificación de email para Luma |
 | eventSponsors | Sponsors de eventos |
 | eventHostOrganizations | Co-hosts de eventos |
 | eventHosts | Hosts individuales de eventos (Luma/manual) |
-| organizerClaims | Claims de organizadores |
+| eventOrganizers | Organizadores individuales de eventos |
 | communityMembers | Miembros de comunidad |
+| communityInvites | Invitaciones de comunidad |
+| communityRoleRequests | Solicitudes de rol en comunidad |
 | importJobs | Jobs de importación |
+| scrapeSources | Fuentes de scraping |
+| scrapeRuns | Ejecuciones de scraping |
+| organizationRelationships | Relaciones del ecosistema |
 
 ## Convenciones
 


### PR DESCRIPTION
## Summary
- refresh the main repo guide around the Peru Agentic Builder Index scope
- remove stale references to claims, subscriptions, submit routes, userPreferences, and pending-events actions
- align admin, god-mode, actions, and db AGENTS docs with the current modules

## Verification
- rg for stale docs references now only finds the active pending-events-list component name
- git diff --check

## Notes
- Biome ignores these markdown paths, so there were no formatter changes to apply.