### PR TITLE
feat: add builder host directory

### DIFF
--- a/app/(landing)/builders/page.tsx
+++ b/app/(landing)/builders/page.tsx
@@ -1,0 +1,231 @@
+import { CalendarDays, ExternalLink, Search, Users } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteFooter } from "@/components/layout/site-footer";
+import { SiteHeader } from "@/components/layout/site-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	type BuilderDirectoryEntry,
+	getBuilderDirectoryEntries,
+	getBuilderDirectorySummary,
+} from "@/lib/builders-directory";
+import { formatEventDate } from "@/lib/event-utils";
+import { sanitizeImageUrl } from "@/lib/utils";
+
+export const metadata: Metadata = {
+	title: "Builders y Hosts | Peru Agentic Builder Index",
+	description:
+		"Directorio publico de builders y hosts activos en eventos de IA, hackathons y comunidades tech en Peru.",
+};
+
+export const dynamic = "force-dynamic";
+
+interface BuildersPageProps {
+	searchParams: Promise<{
+		search?: string;
+	}>;
+}
+
+export default async function BuildersPage({
+	searchParams,
+}: BuildersPageProps) {
+	const params = await searchParams;
+	const search = params.search?.trim() || undefined;
+	const [summary, builders] = await Promise.all([
+		getBuilderDirectorySummary(),
+		getBuilderDirectoryEntries({ search }),
+	]);
+
+	return (
+		<div className="min-h-screen bg-background flex flex-col">
+			<SiteHeader />
+
+			<main className="flex-1">
+				<section className="border-b">
+					<div className="mx-auto max-w-screen-xl px-4 lg:px-8 py-8">
+						<div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
+							<div className="space-y-4">
+								<div className="space-y-3">
+									<h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+										Builders y hosts
+									</h1>
+									<p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+										Personas que aparecen como hosts en eventos publicos del
+										Peru Agentic Builder Index. Es una senal practica de quien
+										organiza, ensena, convoca o mueve comunidades.
+									</p>
+								</div>
+
+								<form action="/builders" className="flex max-w-md gap-2">
+									<div className="flex h-9 flex-1 items-center gap-2 border bg-background px-3">
+										<Search className="size-4 text-muted-foreground" />
+										<input
+											type="search"
+											name="search"
+											defaultValue={search}
+											placeholder="Buscar por nombre"
+											className="h-full min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+										/>
+									</div>
+									<Button type="submit" size="sm">
+										Buscar
+									</Button>
+								</form>
+							</div>
+
+							<div className="grid grid-cols-2 border bg-card">
+								<SummaryMetric label="builders" value={summary.builders} />
+								<SummaryMetric label="eventos" value={summary.events} />
+								<SummaryMetric
+									label="apariciones"
+									value={summary.hostAppearances}
+								/>
+								<SummaryMetric
+									label="upcoming"
+									value={summary.upcomingEvents}
+								/>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section className="mx-auto max-w-screen-xl px-4 lg:px-8 py-6">
+					<div className="mb-4 flex items-center justify-between gap-4">
+						<div>
+							<h2 className="text-sm font-semibold">
+								{search ? "Resultados" : "Top builders por actividad"}
+							</h2>
+							<p className="mt-1 text-xs text-muted-foreground">
+								{builders.length} perfiles derivados de hosts de eventos.
+							</p>
+						</div>
+						{search && (
+							<Button asChild variant="outline" size="sm">
+								<Link href="/builders">Limpiar búsqueda</Link>
+							</Button>
+						)}
+					</div>
+
+					{builders.length > 0 ? (
+						<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+							{builders.map((builder) => (
+								<BuilderCard key={builder.hostKey} builder={builder} />
+							))}
+						</div>
+					) : (
+						<div className="border bg-card p-8 text-center">
+							<p className="text-sm font-medium">No encontramos builders.</p>
+							<p className="mt-1 text-sm text-muted-foreground">
+								Prueba con otro nombre o vuelve al directorio completo.
+							</p>
+						</div>
+					)}
+				</section>
+			</main>
+
+			<SiteFooter />
+		</div>
+	);
+}
+
+function SummaryMetric({ label, value }: { label: string; value: number }) {
+	return (
+		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0">
+			<div className="text-2xl font-semibold tracking-tight">
+				{new Intl.NumberFormat("es-PE").format(value)}
+			</div>
+			<div className="mt-1 text-xs text-muted-foreground">{label}</div>
+		</div>
+	);
+}
+
+function BuilderCard({ builder }: { builder: BuilderDirectoryEntry }) {
+	const avatarUrl = sanitizeImageUrl(builder.avatarUrl);
+	const latestEventHref = builder.latestEventCode
+		? `/e/${builder.latestEventCode}`
+		: null;
+
+	return (
+		<article className="border bg-card p-4">
+			<div className="flex items-start gap-3">
+				<div className="relative flex size-12 shrink-0 items-center justify-center overflow-hidden border bg-muted text-sm font-semibold text-muted-foreground">
+					{avatarUrl ? (
+						<img
+							src={avatarUrl}
+							alt={builder.name}
+							loading="lazy"
+							decoding="async"
+							className="h-full w-full object-cover"
+						/>
+					) : (
+						getInitials(builder.name)
+					)}
+				</div>
+
+				<div className="min-w-0 flex-1">
+					<h3 className="truncate text-sm font-semibold">{builder.name}</h3>
+					<div className="mt-1 flex flex-wrap items-center gap-2">
+						<Badge variant="secondary" className="h-5 rounded-none text-[10px]">
+							{builder.eventCount} eventos
+						</Badge>
+						{builder.upcomingEventCount > 0 && (
+							<Badge variant="outline" className="h-5 rounded-none text-[10px]">
+								{builder.upcomingEventCount} upcoming
+							</Badge>
+						)}
+					</div>
+				</div>
+			</div>
+
+			<div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+				<div className="border p-2">
+					<div className="flex items-center gap-1.5 font-medium">
+						<CalendarDays className="size-3.5" />
+						{builder.hostAppearances}
+					</div>
+					<div className="mt-0.5 text-muted-foreground">apariciones</div>
+				</div>
+				<div className="border p-2">
+					<div className="flex items-center gap-1.5 font-medium">
+						<Users className="size-3.5" />
+						{builder.organizationCount}
+					</div>
+					<div className="mt-0.5 text-muted-foreground">orgs</div>
+				</div>
+			</div>
+
+			<div className="mt-4 border-t pt-3 text-xs">
+				<div className="text-muted-foreground">Última actividad</div>
+				{latestEventHref ? (
+					<Link
+						href={latestEventHref}
+						className="mt-1 flex items-center gap-1.5 font-medium hover:underline"
+					>
+						<span className="line-clamp-1">
+							{builder.latestEventName || "Evento"}
+						</span>
+						<ExternalLink className="size-3 shrink-0" />
+					</Link>
+				) : (
+					<div className="mt-1 font-medium">
+						{builder.latestEventName || "Evento"}
+					</div>
+				)}
+				<div className="mt-1 text-muted-foreground">
+					{builder.latestOrganizationName || "Organización"} ·{" "}
+					{formatEventDate(builder.latestEventAt) || "Sin fecha"}
+				</div>
+			</div>
+		</article>
+	);
+}
+
+function getInitials(name: string) {
+	return name
+		.split(/\s+/)
+		.filter(Boolean)
+		.slice(0, 2)
+		.map((part) => part.charAt(0).toUpperCase())
+		.join("");
+}

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -22,6 +22,7 @@ import { SiteHeader } from "@/components/layout/site-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getEvents } from "@/lib/actions/events";
+import { getBuilderDirectorySummary } from "@/lib/builders-directory";
 import { db } from "@/lib/db";
 import { communityMembers, events, organizations } from "@/lib/db/schema";
 import { ORGANIZER_TYPE_LABELS } from "@/lib/db/schema/constants";
@@ -182,26 +183,20 @@ async function getIndexData() {
 			.limit(4),
 	]);
 
-	const [{ totalCommunities }] = await db
-		.select({ totalCommunities: count(organizations.id) })
-		.from(organizations)
-		.where(publicOrgWhere);
-
-	const [{ totalBuilders }] = await db
-		.select({
-			totalBuilders: sql<number>`count(distinct ${communityMembers.userId})`,
-		})
-		.from(communityMembers)
-		.innerJoin(
-			organizations,
-			eq(communityMembers.communityId, organizations.id),
-		)
-		.where(publicOrgWhere);
-
-	const [{ totalLabs }] = await db
-		.select({ totalLabs: count(organizations.id) })
-		.from(organizations)
-		.where(and(publicOrgWhere, inArray(organizations.type, UNIVERSITY_TYPES)));
+	const [[{ totalCommunities }], builderSummary, [{ totalLabs }]] =
+		await Promise.all([
+			db
+				.select({ totalCommunities: count(organizations.id) })
+				.from(organizations)
+				.where(publicOrgWhere),
+			getBuilderDirectorySummary(),
+			db
+				.select({ totalLabs: count(organizations.id) })
+				.from(organizations)
+				.where(
+					and(publicOrgWhere, inArray(organizations.type, UNIVERSITY_TYPES)),
+				),
+		]);
 
 	const counts = countRows[0] || {
 		eventsCount: 0,
@@ -224,7 +219,7 @@ async function getIndexData() {
 			opportunities: Number(counts.opportunities || 0),
 			cities: Number(counts.cities || 0),
 			communities: Number(totalCommunities || 0),
-			builders: Number(totalBuilders || 0),
+			builders: builderSummary.builders,
 			labs: Number(totalLabs || 0),
 		},
 	};
@@ -342,11 +337,11 @@ export default async function HomePage() {
 								helper="oportunidades"
 							/>
 							<FacetLink
-								href="/c/discover?countries=PE"
+								href="/builders"
 								icon={Code2}
-								label="Builders activos"
+								label="Builders y hosts"
 								value={data.counts.builders}
-								helper="seguimientos"
+								helper="desde eventos"
 							/>
 							<FacetLink
 								href="/roadmap"

--- a/app/(seo)/sitemap.ts
+++ b/app/(seo)/sitemap.ts
@@ -68,6 +68,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.9,
 		},
 		{
+			url: `${baseUrl}/builders`,
+			lastModified: new Date(),
+			changeFrequency: "daily",
+			priority: 0.8,
+		},
+		{
 			url: `${baseUrl}/roadmap`,
 			lastModified: new Date(),
 			changeFrequency: "weekly",

--- a/components/layout/main-nav.tsx
+++ b/components/layout/main-nav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const navItems = [
 	{ href: "/events", label: "Eventos" },
 	{ href: "/c/discover", label: "Comunidades" },
+	{ href: "/builders", label: "Builders" },
 	{ href: "/roadmap", label: "Roadmap" },
 ];
 

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -11,6 +11,7 @@ const navItems = [
 	{ href: "/", label: "Inicio" },
 	{ href: "/events", label: "Eventos" },
 	{ href: "/c/discover", label: "Comunidades" },
+	{ href: "/builders", label: "Builders" },
 ];
 
 const secondaryItems = [

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -39,6 +39,12 @@ export function SiteFooter() {
 									>
 										Comunidades
 									</Link>
+									<Link
+										href="/builders"
+										className="hover:text-foreground transition-colors"
+									>
+										Builders
+									</Link>
 								</nav>
 							</div>
 

--- a/components/search-command.tsx
+++ b/components/search-command.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ArrowRight, Calendar, Command, MapPin, Sparkles } from "lucide-react";
+import {
+	ArrowRight,
+	Calendar,
+	Command,
+	MapPin,
+	Sparkles,
+	Users,
+} from "lucide-react";
 import { useRouter } from "next/navigation";
 import * as React from "react";
 import {
@@ -102,6 +109,12 @@ export function SearchCommand({ hackathons }: SearchCommandProps) {
 					>
 						<Sparkles className="mr-2 h-4 w-4" />
 						Ver eventos para principiantes
+					</CommandItem>
+					<CommandItem
+						onSelect={() => runCommand(() => router.push("/builders"))}
+					>
+						<Users className="mr-2 h-4 w-4" />
+						Explorar builders y hosts
 					</CommandItem>
 				</CommandGroup>
 

--- a/lib/builders-directory.ts
+++ b/lib/builders-directory.ts
@@ -1,0 +1,123 @@
+import { and, desc, eq, ilike, type SQL, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { eventHosts, events, organizations } from "@/lib/db/schema";
+
+const PERU = "PE";
+
+export interface BuilderDirectoryEntry {
+	hostKey: string;
+	name: string;
+	avatarUrl: string | null;
+	eventCount: number;
+	hostAppearances: number;
+	organizationCount: number;
+	upcomingEventCount: number;
+	latestEventAt: Date | null;
+	latestEventName: string | null;
+	latestEventCode: string | null;
+	latestOrganizationName: string | null;
+}
+
+export interface BuilderDirectorySummary {
+	builders: number;
+	hostAppearances: number;
+	events: number;
+	upcomingEvents: number;
+}
+
+export interface BuilderDirectoryFilters {
+	search?: string;
+	limit?: number;
+}
+
+function getHostKeySql() {
+	return sql<string>`lower(trim(${eventHosts.name}))`;
+}
+
+function getBuilderConditions(search?: string): SQL[] {
+	const conditions: SQL[] = [
+		eq(events.isApproved, true),
+		eq(events.country, PERU),
+		sql`trim(${eventHosts.name}) <> ''`,
+	];
+
+	if (search?.trim()) {
+		conditions.push(ilike(eventHosts.name, `%${search.trim()}%`));
+	}
+
+	return conditions;
+}
+
+export async function getBuilderDirectorySummary(): Promise<BuilderDirectorySummary> {
+	const [row] = await db
+		.select({
+			builders: sql<number>`count(distinct ${getHostKeySql()})::int`,
+			hostAppearances: sql<number>`count(${eventHosts.id})::int`,
+			events: sql<number>`count(distinct ${eventHosts.eventId})::int`,
+			upcomingEvents: sql<number>`count(distinct ${events.id}) filter (where ${events.endDate} is null or ${events.endDate} >= now())::int`,
+		})
+		.from(eventHosts)
+		.innerJoin(events, eq(eventHosts.eventId, events.id))
+		.where(and(...getBuilderConditions()));
+
+	return {
+		builders: Number(row?.builders || 0),
+		hostAppearances: Number(row?.hostAppearances || 0),
+		events: Number(row?.events || 0),
+		upcomingEvents: Number(row?.upcomingEvents || 0),
+	};
+}
+
+export async function getBuilderDirectoryEntries({
+	search,
+	limit = 72,
+}: BuilderDirectoryFilters = {}): Promise<BuilderDirectoryEntry[]> {
+	const hostKey = getHostKeySql();
+
+	const rows = await db
+		.select({
+			hostKey,
+			name: sql<string>`min(${eventHosts.name})`,
+			avatarUrl: sql<
+				string | null
+			>`max(${eventHosts.avatarUrl}) filter (where ${eventHosts.avatarUrl} is not null)`,
+			eventCount: sql<number>`count(distinct ${eventHosts.eventId})::int`,
+			hostAppearances: sql<number>`count(${eventHosts.id})::int`,
+			organizationCount: sql<number>`count(distinct ${events.organizationId})::int`,
+			upcomingEventCount: sql<number>`count(distinct ${events.id}) filter (where ${events.endDate} is null or ${events.endDate} >= now())::int`,
+			latestEventAt: sql<Date | null>`max(${events.startDate})`,
+			latestEventName: sql<
+				string | null
+			>`(array_agg(${events.name} order by ${events.startDate} desc nulls last))[1]`,
+			latestEventCode: sql<
+				string | null
+			>`(array_agg(${events.shortCode} order by ${events.startDate} desc nulls last))[1]`,
+			latestOrganizationName: sql<
+				string | null
+			>`(array_agg(coalesce(${organizations.displayName}, ${organizations.name}) order by ${events.startDate} desc nulls last))[1]`,
+		})
+		.from(eventHosts)
+		.innerJoin(events, eq(eventHosts.eventId, events.id))
+		.leftJoin(organizations, eq(events.organizationId, organizations.id))
+		.where(and(...getBuilderConditions(search)))
+		.groupBy(hostKey)
+		.orderBy(
+			desc(sql<number>`count(distinct ${eventHosts.eventId})`),
+			desc(sql<Date>`max(${events.startDate})`),
+		)
+		.limit(limit);
+
+	return rows.map((row) => ({
+		hostKey: row.hostKey,
+		name: row.name,
+		avatarUrl: row.avatarUrl,
+		eventCount: Number(row.eventCount || 0),
+		hostAppearances: Number(row.hostAppearances || 0),
+		organizationCount: Number(row.organizationCount || 0),
+		upcomingEventCount: Number(row.upcomingEventCount || 0),
+		latestEventAt: row.latestEventAt,
+		latestEventName: row.latestEventName,
+		latestEventCode: row.latestEventCode,
+		latestOrganizationName: row.latestOrganizationName,
+	}));
+}


### PR DESCRIPTION
## Summary
- adds a public `/builders` directory powered by Luma event host data
- updates the Agentic Builder Index builder metric to use real host counts
- links the directory from nav, mobile nav, footer, search, sitemap, and the home facet

## Verification
- `bunx biome check --write app/(landing)/builders/page.tsx app/(landing)/page.tsx app/(seo)/sitemap.ts components/layout/main-nav.tsx components/layout/mobile-nav.tsx components/layout/site-footer.tsx components/search-command.tsx lib/builders-directory.ts`
- `bun --bun tsc --noEmit --pretty false`
- `bun run build`
- runtime query check for `getBuilderDirectorySummary()` and `getBuilderDirectoryEntries()`
- local curl checks for `/builders`, `/builders?search=Shiara`, and `/`
- agent-browser desktop and mobile screenshots for `/builders`