### PR TITLE
feat: add index data health page

### DIFF
--- a/app/(landing)/data-health/page.tsx
+++ b/app/(landing)/data-health/page.tsx
@@ -1,0 +1,413 @@
+import {
+	Activity,
+	AlertTriangle,
+	ArrowRight,
+	CheckCircle2,
+	CircleDashed,
+	Database,
+	ExternalLink,
+	ListChecks,
+	Table2,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteFooter } from "@/components/layout/site-footer";
+import { SiteHeader } from "@/components/layout/site-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	type CoverageBreakdownRow,
+	type CoverageFacet,
+	type CoverageStatus,
+	getIndexDataHealth,
+	type QualitySignal,
+} from "@/lib/index-data-health";
+
+export const metadata: Metadata = {
+	title: "Data Health | Peru Agentic Builder Index",
+	description:
+		"Cobertura, fuentes y gaps actuales del Peru Agentic Builder Index.",
+};
+
+export const dynamic = "force-dynamic";
+
+const statusCopy: Record<CoverageStatus, { label: string; className: string }> =
+	{
+		live: {
+			label: "live",
+			className: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600",
+		},
+		needs_backfill: {
+			label: "backfill",
+			className: "border-amber-500/30 bg-amber-500/10 text-amber-600",
+		},
+		not_modeled: {
+			label: "sin modelo",
+			className: "border-muted bg-muted text-muted-foreground",
+		},
+	};
+
+const severityCopy: Record<QualitySignal["severity"], string> = {
+	good: "text-emerald-600",
+	watch: "text-amber-600",
+	fix: "text-red-600",
+};
+
+function formatNumber(value: number) {
+	return new Intl.NumberFormat("es-PE").format(value);
+}
+
+function formatDate(value: Date | null) {
+	if (!value) return "Sin registro";
+	return new Intl.DateTimeFormat("es-PE", {
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+	}).format(value);
+}
+
+export default async function DataHealthPage() {
+	const health = await getIndexDataHealth();
+	const backfillQueue = health.facets.filter(
+		(facet) => facet.status !== "live",
+	);
+	const totalLiveFacets = health.facets.filter(
+		(facet) => facet.status === "live",
+	).length;
+
+	return (
+		<div className="flex min-h-screen flex-col bg-background">
+			<SiteHeader />
+
+			<main className="flex-1">
+				<section className="border-b">
+					<div className="mx-auto max-w-screen-xl px-4 py-10 lg:px-8 lg:py-14">
+						<div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
+							<div className="max-w-3xl space-y-5">
+								<Badge variant="outline" className="gap-2 rounded-none">
+									<Database className="size-3.5" />
+									Data health
+								</Badge>
+								<div className="space-y-3">
+									<h1 className="text-3xl font-semibold tracking-tight sm:text-5xl">
+										Cobertura del Peru Agentic Builder Index
+									</h1>
+									<p className="max-w-2xl text-base leading-7 text-muted-foreground">
+										Vista pública de lo que ya está mapeado, qué viene de datos
+										reales y qué todavía necesita backfill antes del primer
+										State of Agentic Builders in Peru.
+									</p>
+								</div>
+								<div className="flex flex-col gap-2 sm:flex-row">
+									<Button asChild size="sm" className="gap-2">
+										<Link href="/events?country=PE">
+											Ver eventos
+											<ArrowRight className="size-4" />
+										</Link>
+									</Button>
+									<Button asChild variant="outline" size="sm" className="gap-2">
+										<a href="mailto:hey@hack0.dev?subject=Actualizar%20Peru%20Agentic%20Builder%20Index">
+											Reportar dataset
+											<ExternalLink className="size-4" />
+										</a>
+									</Button>
+								</div>
+							</div>
+
+							<div className="grid grid-cols-2 border bg-card">
+								<HeroMetric label="facetas live" value={totalLiveFacets} />
+								<HeroMetric
+									label="facetas totales"
+									value={health.facets.length}
+								/>
+								<HeroMetric
+									label="último evento"
+									value={formatDate(health.updatedAt)}
+									text
+								/>
+								<HeroMetric
+									label="último scrape"
+									value={formatDate(health.latestSourceScrapedAt)}
+									text
+								/>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section className="border-b bg-muted/20">
+					<div className="mx-auto max-w-screen-xl px-4 py-6 lg:px-8">
+						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+							{health.facets.map((facet) => (
+								<CoverageCard key={facet.id} facet={facet} />
+							))}
+						</div>
+					</div>
+				</section>
+
+				<section className="mx-auto grid max-w-screen-xl gap-8 px-4 py-8 lg:grid-cols-[minmax(0,1fr)_380px] lg:px-8">
+					<div className="space-y-8">
+						<SectionHeader
+							icon={ListChecks}
+							title="Backfill queue"
+							description="Trabajo pendiente ordenado por gaps reales del modelo actual."
+						/>
+						<div className="grid gap-3">
+							{backfillQueue.map((facet) => (
+								<BackfillRow key={facet.id} facet={facet} />
+							))}
+						</div>
+
+						<SectionHeader
+							icon={Activity}
+							title="Calidad de datos"
+							description="Campos que afectan SEO, filtros, confianza y directorios públicos."
+						/>
+						<div className="grid gap-3 md:grid-cols-2">
+							{health.qualitySignals.map((signal) => (
+								<QualityCard key={signal.label} signal={signal} />
+							))}
+						</div>
+					</div>
+
+					<aside className="space-y-6">
+						<BreakdownSection
+							title="Fuentes de eventos"
+							rows={health.sourceBreakdown}
+						/>
+						<BreakdownSection
+							title="Tipos de evento"
+							rows={health.eventTypeBreakdown}
+						/>
+						<BreakdownSection
+							title="Tipos de organización"
+							rows={health.organizationTypeBreakdown}
+						/>
+						<BreakdownSection title="Ciudades" rows={health.cityBreakdown} />
+						<OperationsPanel operations={health.operations} />
+					</aside>
+				</section>
+			</main>
+
+			<SiteFooter />
+		</div>
+	);
+}
+
+function HeroMetric({
+	label,
+	value,
+	text = false,
+}: {
+	label: string;
+	value: number | string;
+	text?: boolean;
+}) {
+	return (
+		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0">
+			<div
+				className={
+					text
+						? "text-sm font-semibold tracking-tight"
+						: "text-2xl font-semibold tracking-tight"
+				}
+			>
+				{typeof value === "number" ? formatNumber(value) : value}
+			</div>
+			<div className="mt-1 text-xs text-muted-foreground">{label}</div>
+		</div>
+	);
+}
+
+function CoverageCard({ facet }: { facet: CoverageFacet }) {
+	const status = statusCopy[facet.status];
+	const content = (
+		<div className="group flex min-h-40 flex-col justify-between border bg-background p-4 transition-colors hover:bg-card">
+			<div className="space-y-3">
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<div className="text-2xl font-semibold tracking-tight">
+							{formatNumber(facet.count)}
+						</div>
+						<h2 className="mt-1 text-sm font-medium">{facet.label}</h2>
+					</div>
+					<Badge className={`rounded-none ${status.className}`}>
+						{status.label}
+					</Badge>
+				</div>
+				<div className="space-y-1 text-xs leading-5 text-muted-foreground">
+					<p>{facet.evidence}</p>
+					<p>Fuente: {facet.source}</p>
+				</div>
+			</div>
+			<div className="mt-4 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+				<span className="line-clamp-1">{facet.nextAction}</span>
+				{facet.href && <ArrowRight className="size-3.5 shrink-0" />}
+			</div>
+		</div>
+	);
+
+	if (!facet.href) return content;
+	return <Link href={facet.href}>{content}</Link>;
+}
+
+function SectionHeader({
+	icon: Icon,
+	title,
+	description,
+}: {
+	icon: typeof ListChecks;
+	title: string;
+	description: string;
+}) {
+	return (
+		<div className="flex items-start gap-3">
+			<div className="flex size-9 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
+				<Icon className="size-4" />
+			</div>
+			<div>
+				<h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+				<p className="mt-1 text-sm text-muted-foreground">{description}</p>
+			</div>
+		</div>
+	);
+}
+
+function BackfillRow({ facet }: { facet: CoverageFacet }) {
+	const status = statusCopy[facet.status];
+
+	return (
+		<div className="grid gap-4 border bg-card p-4 md:grid-cols-[180px_minmax(0,1fr)]">
+			<div className="space-y-2">
+				<div className="flex items-center gap-2">
+					{facet.status === "not_modeled" ? (
+						<CircleDashed className="size-4 text-muted-foreground" />
+					) : (
+						<AlertTriangle className="size-4 text-amber-600" />
+					)}
+					<h3 className="text-sm font-semibold">{facet.label}</h3>
+				</div>
+				<Badge className={`rounded-none ${status.className}`}>
+					{status.label}
+				</Badge>
+			</div>
+			<div className="space-y-2 text-sm">
+				<p>{facet.nextAction}</p>
+				<p className="text-xs text-muted-foreground">
+					Evidencia actual: {facet.evidence}. Fuente: {facet.source}.
+				</p>
+			</div>
+		</div>
+	);
+}
+
+function QualityCard({ signal }: { signal: QualitySignal }) {
+	const ratio =
+		signal.total > 0 ? Math.round((signal.value / signal.total) * 100) : 0;
+
+	return (
+		<div className="border bg-card p-4">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h3 className="text-sm font-semibold">{signal.label}</h3>
+					<p className="mt-1 text-xs leading-5 text-muted-foreground">
+						{signal.nextAction}
+					</p>
+				</div>
+				<CheckCircle2 className={`size-4 ${severityCopy[signal.severity]}`} />
+			</div>
+			<div className="mt-4 flex items-end justify-between gap-3">
+				<div className="text-2xl font-semibold tracking-tight">
+					{formatNumber(signal.value)}
+				</div>
+				<div className="text-xs text-muted-foreground">
+					{ratio}% de {formatNumber(signal.total)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function BreakdownSection({
+	title,
+	rows,
+}: {
+	title: string;
+	rows: CoverageBreakdownRow[];
+}) {
+	return (
+		<section className="border bg-card">
+			<div className="flex items-center gap-2 border-b px-4 py-3">
+				<Table2 className="size-4 text-muted-foreground" />
+				<h2 className="text-sm font-semibold">{title}</h2>
+			</div>
+			<div className="divide-y">
+				{rows.length > 0 ? (
+					rows.map((row) => <BreakdownRow key={row.label} row={row} />)
+				) : (
+					<div className="p-4 text-sm text-muted-foreground">Sin datos.</div>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function BreakdownRow({ row }: { row: CoverageBreakdownRow }) {
+	return (
+		<div className="flex items-center justify-between gap-3 px-4 py-3 text-sm">
+			<div className="min-w-0">
+				<div className="truncate font-medium">{row.label}</div>
+				<div className="text-xs text-muted-foreground">{row.helper}</div>
+			</div>
+			<div className="shrink-0 font-semibold">{formatNumber(row.count)}</div>
+		</div>
+	);
+}
+
+function OperationsPanel({
+	operations,
+}: {
+	operations: {
+		activeScrapeSources: number;
+		scrapeRuns: number;
+		completedScrapeRuns: number;
+		failedScrapeRuns: number;
+		importedMemberships: number;
+		claimedProfiles: number;
+		sponsors: number;
+		sponsoredEvents: number;
+		relationships: number;
+	};
+}) {
+	const rows = [
+		["scrape sources activos", operations.activeScrapeSources],
+		["scrape runs", operations.scrapeRuns],
+		["scrape runs ok", operations.completedScrapeRuns],
+		["scrape runs fallidos", operations.failedScrapeRuns],
+		["memberships", operations.importedMemberships],
+		["perfiles reclamados", operations.claimedProfiles],
+		["sponsors", operations.sponsors],
+		["eventos con sponsors", operations.sponsoredEvents],
+		["relaciones org", operations.relationships],
+	] as const;
+
+	return (
+		<section className="border bg-card">
+			<div className="flex items-center gap-2 border-b px-4 py-3">
+				<Database className="size-4 text-muted-foreground" />
+				<h2 className="text-sm font-semibold">Operaciones</h2>
+			</div>
+			<div className="divide-y">
+				{rows.map(([label, value]) => (
+					<div
+						key={label}
+						className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+					>
+						<span className="text-muted-foreground">{label}</span>
+						<span className="font-semibold">{formatNumber(value)}</span>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -450,7 +450,7 @@ export default async function HomePage() {
 										</div>
 									</div>
 									<Button asChild variant="outline" size="sm">
-										<Link href="/roadmap">Ver roadmap</Link>
+										<Link href="/data-health">Ver cobertura</Link>
 									</Button>
 								</div>
 							</div>

--- a/app/(seo)/sitemap.ts
+++ b/app/(seo)/sitemap.ts
@@ -74,6 +74,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/data-health`,
+			lastModified: new Date(),
+			changeFrequency: "daily",
+			priority: 0.7,
+		},
+		{
 			url: `${baseUrl}/roadmap`,
 			lastModified: new Date(),
 			changeFrequency: "weekly",

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -57,6 +57,12 @@ export function SiteFooter() {
 									>
 										Roadmap
 									</Link>
+									<Link
+										href="/data-health"
+										className="hover:text-foreground transition-colors"
+									>
+										Data health
+									</Link>
 									<a
 										href="mailto:hey@hack0.dev"
 										className="hover:text-foreground transition-colors"

--- a/components/search-command.tsx
+++ b/components/search-command.tsx
@@ -4,6 +4,7 @@ import {
 	ArrowRight,
 	Calendar,
 	Command,
+	Database,
 	MapPin,
 	Sparkles,
 	Users,
@@ -115,6 +116,12 @@ export function SearchCommand({ hackathons }: SearchCommandProps) {
 					>
 						<Users className="mr-2 h-4 w-4" />
 						Explorar builders y hosts
+					</CommandItem>
+					<CommandItem
+						onSelect={() => runCommand(() => router.push("/data-health"))}
+					>
+						<Database className="mr-2 h-4 w-4" />
+						Ver cobertura del índice
 					</CommandItem>
 				</CommandGroup>
 

--- a/lib/index-data-health.ts
+++ b/lib/index-data-health.ts
@@ -1,0 +1,449 @@
+import { and, count, desc, eq, isNull, sql } from "drizzle-orm";
+import { getBuilderDirectorySummary } from "@/lib/builders-directory";
+import { db } from "@/lib/db";
+import {
+	communityMembers,
+	eventHosts,
+	eventSponsors,
+	events,
+	organizationRelationships,
+	organizations,
+	scrapeRuns,
+	scrapeSources,
+	users,
+} from "@/lib/db/schema";
+import {
+	EVENT_TYPE_LABELS,
+	ORGANIZER_TYPE_LABELS,
+} from "@/lib/db/schema/constants";
+
+const PERU = "PE";
+const HACKATHON_TYPES = [
+	"hackathon",
+	"competition",
+	"olympiad",
+	"robotics",
+] as const;
+const OPPORTUNITY_TYPES = [
+	"accelerator",
+	"incubator",
+	"fellowship",
+	"call_for_papers",
+] as const;
+const UNIVERSITY_TYPES = ["university", "student_org"] as const;
+
+export type CoverageStatus = "live" | "needs_backfill" | "not_modeled";
+
+export type CoverageFacet = {
+	id: string;
+	label: string;
+	count: number;
+	status: CoverageStatus;
+	href: string | null;
+	source: string;
+	evidence: string;
+	nextAction: string;
+};
+
+export type CoverageBreakdownRow = {
+	label: string;
+	count: number;
+	helper: string;
+};
+
+export type QualitySignal = {
+	label: string;
+	value: number;
+	total: number;
+	severity: "good" | "watch" | "fix";
+	nextAction: string;
+};
+
+export type IndexDataHealth = {
+	updatedAt: Date | null;
+	latestSourceScrapedAt: Date | null;
+	facets: CoverageFacet[];
+	sourceBreakdown: CoverageBreakdownRow[];
+	eventTypeBreakdown: CoverageBreakdownRow[];
+	organizationTypeBreakdown: CoverageBreakdownRow[];
+	cityBreakdown: CoverageBreakdownRow[];
+	qualitySignals: QualitySignal[];
+	operations: {
+		activeScrapeSources: number;
+		scrapeRuns: number;
+		completedScrapeRuns: number;
+		failedScrapeRuns: number;
+		importedMemberships: number;
+		claimedProfiles: number;
+		sponsors: number;
+		sponsoredEvents: number;
+		relationships: number;
+	};
+};
+
+function toNumber(value: unknown) {
+	return Number(value || 0);
+}
+
+function toDate(value: Date | string | null | undefined) {
+	if (!value) return null;
+	const date = value instanceof Date ? value : new Date(value);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function statusFor(countValue: number, modeled = true): CoverageStatus {
+	if (!modeled) return "not_modeled";
+	return countValue > 0 ? "live" : "needs_backfill";
+}
+
+function signalSeverity(
+	value: number,
+	total: number,
+): QualitySignal["severity"] {
+	if (total === 0 || value === 0) return "good";
+	const ratio = value / total;
+	if (ratio >= 0.3) return "fix";
+	return "watch";
+}
+
+export async function getIndexDataHealth(): Promise<IndexDataHealth> {
+	const publicOrgWhere = and(
+		eq(organizations.isPublic, true),
+		eq(organizations.isPersonalOrg, false),
+		eq(organizations.country, PERU),
+	);
+	const approvedPeruEventsWhere = and(
+		eq(events.isApproved, true),
+		eq(events.country, PERU),
+		isNull(events.parentEventId),
+	);
+
+	const [
+		[eventCounts],
+		[organizationCounts],
+		builderSummary,
+		[membershipCounts],
+		[sponsorCounts],
+		[relationshipCounts],
+		[userCounts],
+		[scrapeCounts],
+		sourceRows,
+		eventTypeRows,
+		organizationTypeRows,
+		cityRows,
+		[qualityCounts],
+	] = await Promise.all([
+		db
+			.select({
+				eventsCount: count(events.id),
+				upcomingEvents: sql<number>`count(*) filter (where ${events.endDate} is null or ${events.endDate} >= now())::int`,
+				hackathons: sql<number>`count(*) filter (where ${events.eventType} in ('hackathon', 'competition', 'olympiad', 'robotics'))::int`,
+				opportunities: sql<number>`count(*) filter (where ${events.eventType} in ('accelerator', 'incubator', 'fellowship', 'call_for_papers'))::int`,
+				cities: sql<number>`count(distinct ${events.city}) filter (where ${events.city} is not null and btrim(${events.city}) <> '')::int`,
+				updatedAt: sql<Date | null>`max(${events.updatedAt})`,
+				latestSourceScrapedAt: sql<Date | null>`max(${events.sourceScrapedAt})`,
+			})
+			.from(events)
+			.where(approvedPeruEventsWhere),
+		db
+			.select({
+				totalOrganizations: count(organizations.id),
+				verifiedOrganizations: sql<number>`count(*) filter (where ${organizations.isVerified} = true)::int`,
+				labs: sql<number>`count(*) filter (where ${organizations.type} in ('university', 'student_org'))::int`,
+				missingLogos: sql<number>`count(*) filter (where ${organizations.logoUrl} is null or btrim(${organizations.logoUrl}) = '')::int`,
+				missingWebsites: sql<number>`count(*) filter (where ${organizations.websiteUrl} is null or btrim(${organizations.websiteUrl}) = '')::int`,
+			})
+			.from(organizations)
+			.where(publicOrgWhere),
+		getBuilderDirectorySummary(),
+		db
+			.select({
+				importedMemberships: count(communityMembers.id),
+				uniqueMembers: sql<number>`count(distinct ${communityMembers.userId})::int`,
+			})
+			.from(communityMembers)
+			.innerJoin(
+				organizations,
+				eq(communityMembers.communityId, organizations.id),
+			)
+			.where(publicOrgWhere),
+		db
+			.select({
+				sponsors: count(eventSponsors.id),
+				sponsoredEvents: sql<number>`count(distinct ${eventSponsors.eventId})::int`,
+			})
+			.from(eventSponsors)
+			.innerJoin(events, eq(eventSponsors.eventId, events.id))
+			.where(approvedPeruEventsWhere),
+		db
+			.select({
+				relationships: count(organizationRelationships.id),
+			})
+			.from(organizationRelationships),
+		db
+			.select({
+				claimedProfiles: count(users.id),
+				publicPeruProfiles: sql<number>`count(*) filter (where ${users.isPublic} = true and ${users.country} = ${PERU})::int`,
+			})
+			.from(users),
+		db
+			.select({
+				activeScrapeSources: sql<number>`count(*) filter (where ${scrapeSources.isActive} = true)::int`,
+				scrapeRuns: sql<number>`count(${scrapeRuns.id})::int`,
+				completedScrapeRuns: sql<number>`count(${scrapeRuns.id}) filter (where ${scrapeRuns.status} = 'completed')::int`,
+				failedScrapeRuns: sql<number>`count(${scrapeRuns.id}) filter (where ${scrapeRuns.status} = 'failed')::int`,
+			})
+			.from(scrapeSources)
+			.leftJoin(scrapeRuns, eq(scrapeRuns.sourceId, scrapeSources.id)),
+		db
+			.select({
+				source: events.scrapeSource,
+				count: count(events.id),
+			})
+			.from(events)
+			.where(approvedPeruEventsWhere)
+			.groupBy(events.scrapeSource)
+			.orderBy(desc(count(events.id)))
+			.limit(8),
+		db
+			.select({
+				eventType: events.eventType,
+				count: count(events.id),
+			})
+			.from(events)
+			.where(approvedPeruEventsWhere)
+			.groupBy(events.eventType)
+			.orderBy(desc(count(events.id)))
+			.limit(8),
+		db
+			.select({
+				type: organizations.type,
+				count: count(organizations.id),
+			})
+			.from(organizations)
+			.where(publicOrgWhere)
+			.groupBy(organizations.type)
+			.orderBy(desc(count(organizations.id)))
+			.limit(8),
+		db
+			.select({
+				city: events.city,
+				count: count(events.id),
+			})
+			.from(events)
+			.where(approvedPeruEventsWhere)
+			.groupBy(events.city)
+			.orderBy(desc(count(events.id)))
+			.limit(8),
+		db
+			.select({
+				eventsWithoutCity: sql<number>`count(distinct ${events.id}) filter (where ${events.city} is null or btrim(${events.city}) = '')::int`,
+				eventsWithoutImage: sql<number>`count(distinct ${events.id}) filter (where ${events.eventImageUrl} is null or btrim(${events.eventImageUrl}) = '')::int`,
+				eventsWithoutHosts: sql<number>`count(distinct ${events.id}) filter (where ${eventHosts.id} is null)::int`,
+			})
+			.from(events)
+			.leftJoin(eventHosts, eq(eventHosts.eventId, events.id))
+			.where(approvedPeruEventsWhere),
+	]);
+
+	const totalEvents = toNumber(eventCounts?.eventsCount);
+	const totalOrganizations = toNumber(organizationCounts?.totalOrganizations);
+	const hackathons = toNumber(eventCounts?.hackathons);
+	const opportunities = toNumber(eventCounts?.opportunities);
+	const labs = toNumber(organizationCounts?.labs);
+	const builders = toNumber(builderSummary.builders);
+
+	const facets: CoverageFacet[] = [
+		{
+			id: "events",
+			label: "Eventos",
+			count: totalEvents,
+			status: statusFor(totalEvents),
+			href: "/events?country=PE",
+			source: "events",
+			evidence: `${toNumber(eventCounts?.upcomingEvents)} upcoming, ${toNumber(eventCounts?.cities)} ciudades`,
+			nextAction:
+				"Mantener Luma como fuente primaria y completar ciudad, imagen y hosts.",
+		},
+		{
+			id: "communities",
+			label: "Comunidades",
+			count: totalOrganizations,
+			status: statusFor(totalOrganizations),
+			href: "/c/discover?countries=PE",
+			source: "organizations",
+			evidence: `${toNumber(organizationCounts?.verifiedOrganizations)} verificadas`,
+			nextAction:
+				"Completar logo, website y tipo de comunidad en cada organización pública.",
+		},
+		{
+			id: "hackathons",
+			label: "Hackathons",
+			count: hackathons,
+			status: statusFor(hackathons),
+			href: "/events?country=PE&eventType=hackathon,competition,olympiad,robotics",
+			source: "events.event_type",
+			evidence: HACKATHON_TYPES.join(", "),
+			nextAction:
+				"Separar hackathons reales de talleres y charlas durante el backfill.",
+		},
+		{
+			id: "labs",
+			label: "Labs universitarios",
+			count: labs,
+			status: statusFor(labs),
+			href: "/c/discover?countries=PE&types=university,student_org",
+			source: "organizations.type",
+			evidence: UNIVERSITY_TYPES.join(", "),
+			nextAction:
+				"Backfill de laboratorios, capítulos ACM/IEEE y grupos estudiantiles.",
+		},
+		{
+			id: "opportunities",
+			label: "Grants y programas",
+			count: opportunities,
+			status: statusFor(opportunities),
+			href: "/events?country=PE&eventType=accelerator,incubator,fellowship,call_for_papers",
+			source: "events.event_type",
+			evidence: OPPORTUNITY_TYPES.join(", "),
+			nextAction:
+				"Importar becas, grants, incubadoras, aceleradoras y convocatorias abiertas.",
+		},
+		{
+			id: "builders",
+			label: "Builders y hosts",
+			count: builders,
+			status: statusFor(builders),
+			href: "/builders",
+			source: "event_hosts",
+			evidence: `${toNumber(builderSummary.hostAppearances)} apariciones en ${toNumber(builderSummary.events)} eventos`,
+			nextAction:
+				"Dedupe manual de nombres, perfiles reclamables y links sociales.",
+		},
+		{
+			id: "demos",
+			label: "Demo projects",
+			count: 0,
+			status: statusFor(0, false),
+			href: null,
+			source: "pendiente",
+			evidence: "sin modelo público",
+			nextAction:
+				"Crear dataset mínimo: evento, demo, GitHub, equipo, video y tags.",
+		},
+		{
+			id: "workflows",
+			label: "AI workflows",
+			count: 0,
+			status: statusFor(0, false),
+			href: null,
+			source: "pendiente",
+			evidence: "sin modelo público",
+			nextAction: "Curar workflows reutilizables desde demos y eventos de IA.",
+		},
+	];
+
+	const sourceBreakdown = sourceRows.map((row) => ({
+		label: row.source || "manual",
+		count: toNumber(row.count),
+		helper: "eventos aprobados PE",
+	}));
+
+	const eventTypeBreakdown = eventTypeRows.map((row) => ({
+		label: row.eventType
+			? EVENT_TYPE_LABELS[row.eventType] || row.eventType
+			: "Sin tipo",
+		count: toNumber(row.count),
+		helper: row.eventType || "sin_tipo",
+	}));
+
+	const organizationTypeBreakdown = organizationTypeRows.map((row) => ({
+		label: row.type ? ORGANIZER_TYPE_LABELS[row.type] || row.type : "Sin tipo",
+		count: toNumber(row.count),
+		helper: row.type || "sin_tipo",
+	}));
+
+	const cityBreakdown = cityRows.map((row) => ({
+		label: row.city || "Sin ciudad",
+		count: toNumber(row.count),
+		helper: "eventos aprobados PE",
+	}));
+
+	const qualitySignals: QualitySignal[] = [
+		{
+			label: "Eventos sin ciudad",
+			value: toNumber(qualityCounts?.eventsWithoutCity),
+			total: totalEvents,
+			severity: signalSeverity(
+				toNumber(qualityCounts?.eventsWithoutCity),
+				totalEvents,
+			),
+			nextAction: "Completar city y department para mapa, SEO local y filtros.",
+		},
+		{
+			label: "Eventos sin imagen",
+			value: toNumber(qualityCounts?.eventsWithoutImage),
+			total: totalEvents,
+			severity: signalSeverity(
+				toNumber(qualityCounts?.eventsWithoutImage),
+				totalEvents,
+			),
+			nextAction:
+				"Usar imagen de Luma o cover manual antes de promover eventos.",
+		},
+		{
+			label: "Eventos sin hosts",
+			value: toNumber(qualityCounts?.eventsWithoutHosts),
+			total: totalEvents,
+			severity: signalSeverity(
+				toNumber(qualityCounts?.eventsWithoutHosts),
+				totalEvents,
+			),
+			nextAction:
+				"Revisar Luma imports sin hosts y asignar organizadores visibles.",
+		},
+		{
+			label: "Organizaciones sin logo",
+			value: toNumber(organizationCounts?.missingLogos),
+			total: totalOrganizations,
+			severity: signalSeverity(
+				toNumber(organizationCounts?.missingLogos),
+				totalOrganizations,
+			),
+			nextAction:
+				"Agregar logo para que el directorio sea usable y reconocible.",
+		},
+		{
+			label: "Organizaciones sin website",
+			value: toNumber(organizationCounts?.missingWebsites),
+			total: totalOrganizations,
+			severity: signalSeverity(
+				toNumber(organizationCounts?.missingWebsites),
+				totalOrganizations,
+			),
+			nextAction: "Agregar web, Luma, LinkedIn, GitHub o Instagram oficial.",
+		},
+	];
+
+	return {
+		updatedAt: toDate(eventCounts?.updatedAt),
+		latestSourceScrapedAt: toDate(eventCounts?.latestSourceScrapedAt),
+		facets,
+		sourceBreakdown,
+		eventTypeBreakdown,
+		organizationTypeBreakdown,
+		cityBreakdown,
+		qualitySignals,
+		operations: {
+			activeScrapeSources: toNumber(scrapeCounts?.activeScrapeSources),
+			scrapeRuns: toNumber(scrapeCounts?.scrapeRuns),
+			completedScrapeRuns: toNumber(scrapeCounts?.completedScrapeRuns),
+			failedScrapeRuns: toNumber(scrapeCounts?.failedScrapeRuns),
+			importedMemberships: toNumber(membershipCounts?.importedMemberships),
+			claimedProfiles: toNumber(userCounts?.claimedProfiles),
+			sponsors: toNumber(sponsorCounts?.sponsors),
+			sponsoredEvents: toNumber(sponsorCounts?.sponsoredEvents),
+			relationships: toNumber(relationshipCounts?.relationships),
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- adds `/data-health` as a public coverage and source-health page for the Peru Agentic Builder Index
- centralizes coverage queries in `getIndexDataHealth()` across events, orgs, builders, sources, quality gaps, and operations
- links the page from the home report card, footer, search command, and sitemap

## Current data findings
- live facets: events 118, communities 148, hackathons 17, builders 142
- backfill gaps: labs 0, grants/programs 0
- not modeled yet: demo projects, AI workflows
- data quality gaps: 69 events without city, 105 organizations without website

## Verification
- `bunx biome check --write app/(landing)/data-health/page.tsx app/(landing)/page.tsx app/(seo)/sitemap.ts components/layout/site-footer.tsx components/search-command.tsx lib/index-data-health.ts`
- `bun -e "import { getIndexDataHealth } from \"./lib/index-data-health\"; const health = await getIndexDataHealth(); console.log(...)"`
- `bun --bun tsc --noEmit --pretty false`
- `bun run build`
- local curl checks for `/data-health` and `/`
- agent-browser desktop and mobile checks for `/data-health`