### PR TITLE
fix: normalize Luma event locations

### DIFF
--- a/lib/index-data-health.ts
+++ b/lib/index-data-health.ts
@@ -237,7 +237,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			.limit(8),
 		db
 			.select({
-				eventsWithoutCity: sql<number>`count(distinct ${events.id}) filter (where ${events.city} is null or btrim(${events.city}) = '')::int`,
+				physicalEventsWithoutCity: sql<number>`count(distinct ${events.id}) filter (where ${events.format} in ('in-person', 'hybrid') and (${events.city} is null or btrim(${events.city}) = ''))::int`,
 				eventsWithoutImage: sql<number>`count(distinct ${events.id}) filter (where ${events.eventImageUrl} is null or btrim(${events.eventImageUrl}) = '')::int`,
 				eventsWithoutHosts: sql<number>`count(distinct ${events.id}) filter (where ${eventHosts.id} is null)::int`,
 			})
@@ -371,11 +371,11 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 
 	const qualitySignals: QualitySignal[] = [
 		{
-			label: "Eventos sin ciudad",
-			value: toNumber(qualityCounts?.eventsWithoutCity),
+			label: "Eventos físicos sin ciudad",
+			value: toNumber(qualityCounts?.physicalEventsWithoutCity),
 			total: totalEvents,
 			severity: signalSeverity(
-				toNumber(qualityCounts?.eventsWithoutCity),
+				toNumber(qualityCounts?.physicalEventsWithoutCity),
 				totalEvents,
 			),
 			nextAction: "Completar city y department para mapa, SEO local y filtros.",

--- a/lib/luma/calendar-sync.ts
+++ b/lib/luma/calendar-sync.ts
@@ -1,7 +1,7 @@
 import { and, eq, notInArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { eventHosts, events, organizations } from "@/lib/db/schema";
-import { normalizeCountryCode } from "@/lib/event-utils";
+import { resolveLumaEventLocation } from "@/lib/luma/location";
 import { inferEventType } from "@/lib/scraper/luma-schema";
 import {
 	createUniqueSlug,
@@ -53,6 +53,7 @@ type LumaEvent = {
 	geo_longitude?: string | null;
 	visibility?: string | null;
 	duration_interval?: string | null;
+	location_type?: string | null;
 	host?: string | null;
 	tags?: string[];
 };
@@ -122,14 +123,6 @@ function normalizeEventUrl(event: LumaEvent) {
 function truncate(value: string | null | undefined, max: number) {
 	if (!value) return null;
 	return value.length > max ? value.slice(0, max) : value;
-}
-
-function coordinateValue(...values: Array<number | string | null | undefined>) {
-	const value = values.find(
-		(candidate) => candidate !== null && candidate !== undefined,
-	);
-	if (value === null || value === undefined) return null;
-	return String(value);
 }
 
 function durationEndDate(startDate: Date | null, interval?: string | null) {
@@ -366,7 +359,6 @@ async function syncEvent(
 	);
 	const description =
 		detailedEvent.description_md || detailedEvent.description || null;
-	const geo = detailedEvent.geo_address_json || detailedEvent.geo_address_info;
 	const startDate = detailedEvent.start_at
 		? new Date(detailedEvent.start_at)
 		: null;
@@ -374,9 +366,16 @@ async function syncEvent(
 		? new Date(detailedEvent.end_at)
 		: durationEndDate(startDate, detailedEvent.duration_interval);
 	const meetingUrl = detailedEvent.meeting_url || null;
-	const format = !geo && meetingUrl ? "virtual" : "in-person";
-	const country =
-		normalizeCountryCode(geo?.country_code || geo?.country || null) || "PE";
+	const location = resolveLumaEventLocation({
+		geoAddress: detailedEvent.geo_address_json,
+		geoAddressInfo: detailedEvent.geo_address_info,
+		coordinate: detailedEvent.coordinate,
+		geoLatitude: detailedEvent.geo_latitude,
+		geoLongitude: detailedEvent.geo_longitude,
+		meetingUrl,
+		locationType: detailedEvent.location_type,
+		countryFallback: "PE",
+	});
 	const status = statusFromDates(startDate, endDate);
 	const eventType = inferEventType(
 		detailedEvent.name,
@@ -405,26 +404,13 @@ async function syncEvent(
 				startDate,
 				endDate,
 				timezone: detailedEvent.timezone || "America/Lima",
-				format,
-				country,
-				department: truncate(geo?.region, 100),
-				city: truncate(geo?.city, 100),
-				venue: truncate(
-					geo?.description || geo?.short_address || geo?.address,
-					255,
-				),
-				geoLatitude:
-					coordinateValue(
-						detailedEvent.geo_latitude,
-						geo?.latitude,
-						detailedEvent.coordinate?.latitude,
-					) || existing.geoLatitude,
-				geoLongitude:
-					coordinateValue(
-						detailedEvent.geo_longitude,
-						geo?.longitude,
-						detailedEvent.coordinate?.longitude,
-					) || existing.geoLongitude,
+				format: location.format,
+				country: location.country,
+				department: truncate(location.department, 100),
+				city: truncate(location.city, 100),
+				venue: truncate(location.venue, 255),
+				geoLatitude: location.geoLatitude || existing.geoLatitude,
+				geoLongitude: location.geoLongitude || existing.geoLongitude,
 				meetingUrl,
 				registrationUrl: detailedEvent.url,
 				eventImageUrl: detailedEvent.cover_url || existing.eventImageUrl,
@@ -461,26 +447,13 @@ async function syncEvent(
 			startDate,
 			endDate,
 			timezone: detailedEvent.timezone || "America/Lima",
-			format,
-			country,
-			department: truncate(geo?.region, 100),
-			city: truncate(geo?.city, 100),
-			venue: truncate(
-				geo?.description || geo?.short_address || geo?.address,
-				255,
-			),
-			geoLatitude:
-				coordinateValue(
-					detailedEvent.geo_latitude,
-					geo?.latitude,
-					detailedEvent.coordinate?.latitude,
-				) || null,
-			geoLongitude:
-				coordinateValue(
-					detailedEvent.geo_longitude,
-					geo?.longitude,
-					detailedEvent.coordinate?.longitude,
-				) || null,
+			format: location.format,
+			country: location.country,
+			department: truncate(location.department, 100),
+			city: truncate(location.city, 100),
+			venue: truncate(location.venue, 255),
+			geoLatitude: location.geoLatitude,
+			geoLongitude: location.geoLongitude,
 			meetingUrl,
 			websiteUrl: detailedEvent.url,
 			registrationUrl: detailedEvent.url,

--- a/lib/luma/location.ts
+++ b/lib/luma/location.ts
@@ -1,0 +1,238 @@
+import { normalizeCountryCode } from "@/lib/event-utils";
+
+type LumaGeoAddress = {
+	city?: string | null;
+	region?: string | null;
+	country?: string | null;
+	country_code?: string | null;
+	address?: string | null;
+	description?: string | null;
+	full_address?: string | null;
+	short_address?: string | null;
+	city_state?: string | null;
+	mode?: string | null;
+	type?: string | null;
+	latitude?: number | string | null;
+	longitude?: number | string | null;
+};
+
+type LumaCoordinate = {
+	latitude?: number | string | null;
+	longitude?: number | string | null;
+};
+
+export type LumaLocationInput = {
+	geoAddress?: LumaGeoAddress | null;
+	geoAddressInfo?: LumaGeoAddress | null;
+	coordinate?: LumaCoordinate | null;
+	geoLatitude?: number | string | null;
+	geoLongitude?: number | string | null;
+	meetingUrl?: string | null;
+	locationType?: string | null;
+	countryFallback?: string | null;
+};
+
+export type LumaLocationResult = {
+	format: "virtual" | "in-person" | "hybrid";
+	country: string;
+	department: string | null;
+	city: string | null;
+	venue: string | null;
+	geoLatitude: string | null;
+	geoLongitude: string | null;
+};
+
+const VIRTUAL_LOCATION_TYPES = new Set([
+	"discord",
+	"google_meet",
+	"livestream",
+	"meet",
+	"online",
+	"stream",
+	"teams",
+	"twitch",
+	"virtual",
+	"youtube",
+	"zoom",
+]);
+
+const PHYSICAL_LOCATION_TYPES = new Set([
+	"address",
+	"manual",
+	"offline",
+	"physical",
+	"shown",
+	"venue",
+]);
+
+const PERU_PLACE_MATCHERS = [
+	{
+		city: "Lima",
+		department: "Lima",
+		patterns: [
+			"barranco",
+			"chorrillos",
+			"jesus maria",
+			"la molina",
+			"lince",
+			"lima",
+			"magdalena",
+			"miraflores",
+			"pueblo libre",
+			"san borja",
+			"san isidro",
+			"san miguel",
+			"santiago de surco",
+			"surco",
+			"surquillo",
+			"villa el salvador",
+		],
+	},
+	{ city: "Callao", department: "Callao", patterns: ["callao"] },
+	{ city: "Arequipa", department: "Arequipa", patterns: ["arequipa"] },
+	{ city: "Cusco", department: "Cusco", patterns: ["cusco", "cuzco"] },
+	{ city: "Trujillo", department: "La Libertad", patterns: ["trujillo"] },
+	{ city: "Chiclayo", department: "Lambayeque", patterns: ["chiclayo"] },
+	{ city: "Piura", department: "Piura", patterns: ["piura"] },
+	{ city: "Huancayo", department: "Junín", patterns: ["huancayo"] },
+	{ city: "Iquitos", department: "Loreto", patterns: ["iquitos"] },
+	{ city: "Tacna", department: "Tacna", patterns: ["tacna"] },
+];
+
+function cleanText(value: string | null | undefined) {
+	const text = value?.trim();
+	return text ? text : null;
+}
+
+function normalizeToken(value: string) {
+	return value
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.toLowerCase();
+}
+
+function firstText(...values: Array<string | null | undefined>) {
+	for (const value of values) {
+		const text = cleanText(value);
+		if (text) return text;
+	}
+	return null;
+}
+
+function coordinateValue(...values: Array<number | string | null | undefined>) {
+	const value = values.find(
+		(candidate) => candidate !== null && candidate !== undefined,
+	);
+	if (value === null || value === undefined) return null;
+	return String(value);
+}
+
+function inferPeruPlace(...values: Array<string | null | undefined>) {
+	const haystack = values
+		.map((value) => (value ? normalizeToken(value) : ""))
+		.filter(Boolean)
+		.join(" ");
+
+	if (!haystack) return null;
+
+	for (const place of PERU_PLACE_MATCHERS) {
+		if (place.patterns.some((pattern) => haystack.includes(pattern))) {
+			return { city: place.city, department: place.department };
+		}
+	}
+
+	return null;
+}
+
+function normalizeCity(
+	value: string | null | undefined,
+	fallback?: string | null,
+) {
+	const place = inferPeruPlace(value);
+	return place?.city || cleanText(value) || fallback || null;
+}
+
+function normalizeDepartment(
+	value: string | null | undefined,
+	fallback?: string | null,
+) {
+	const place = inferPeruPlace(value);
+	return place?.department || cleanText(value) || fallback || null;
+}
+
+function locationTypeFrom(
+	input: LumaLocationInput,
+	geo: LumaGeoAddress | null,
+) {
+	return normalizeToken(
+		firstText(
+			input.locationType,
+			geo?.type,
+			geo?.mode,
+			input.geoAddressInfo?.mode,
+		) || "",
+	);
+}
+
+function resolveFormat(
+	locationType: string,
+	meetingUrl: string | null,
+	hasPhysicalLocation: boolean,
+): LumaLocationResult["format"] {
+	const isVirtual =
+		VIRTUAL_LOCATION_TYPES.has(locationType) || Boolean(meetingUrl);
+	const isPhysical =
+		hasPhysicalLocation || PHYSICAL_LOCATION_TYPES.has(locationType);
+
+	if (isVirtual && isPhysical) return "hybrid";
+	if (isVirtual) return "virtual";
+	return "in-person";
+}
+
+export function resolveLumaEventLocation(
+	input: LumaLocationInput,
+): LumaLocationResult {
+	const geo = input.geoAddress || input.geoAddressInfo || null;
+	const venue = firstText(
+		geo?.description,
+		geo?.short_address,
+		geo?.address,
+		geo?.full_address,
+	);
+	const inferredPlace = inferPeruPlace(
+		geo?.city,
+		geo?.region,
+		geo?.city_state,
+		venue,
+	);
+	const city = normalizeCity(geo?.city, inferredPlace?.city);
+	const department = normalizeDepartment(
+		geo?.region,
+		inferredPlace?.department,
+	);
+	const meetingUrl = cleanText(input.meetingUrl);
+	const locationType = locationTypeFrom(input, geo);
+	const hasPhysicalLocation = Boolean(venue || city || department);
+	const country =
+		normalizeCountryCode(geo?.country_code || geo?.country || null) ||
+		input.countryFallback ||
+		"PE";
+
+	return {
+		format: resolveFormat(locationType, meetingUrl, hasPhysicalLocation),
+		country,
+		department,
+		city,
+		venue,
+		geoLatitude: coordinateValue(
+			input.geoLatitude,
+			geo?.latitude,
+			input.coordinate?.latitude,
+		),
+		geoLongitude: coordinateValue(
+			input.geoLongitude,
+			geo?.longitude,
+			input.coordinate?.longitude,
+		),
+	};
+}


### PR DESCRIPTION
## Summary
- adds a shared Luma location resolver for format, country, city, department, venue, and coordinates
- uses Luma `location_type` so Meet, Zoom, YouTube, and similar events sync as virtual instead of in-person
- infers Lima/Peru city data from common address strings and districts when Luma only sends a manual address
- changes data-health to report physical/hybrid events without city instead of counting virtual events as missing location

## Data impact
- projected PE events checked: 118
- current physical/hybrid missing city: 51
- projected physical/hybrid missing city after normalization: 13
- events reclassified from in-person to virtual: 35
- events with city inferred from raw location data: 3

## Verification
- `bunx biome check --write lib/luma/location.ts lib/luma/calendar-sync.ts lib/index-data-health.ts`
- resolver sample checks for Meet, Zoom, Lima address, Provincia de Lima, and hybrid inputs
- projected data-impact query against current DB
- `bun run sync:luma --dry-run --limit=5`
- `bun --bun tsc --noEmit --pretty false`
- `bun run build`