### PR TITLE
feat: add opportunities directory

### DIFF
--- a/app/(landing)/opportunities/page.tsx
+++ b/app/(landing)/opportunities/page.tsx
@@ -1,0 +1,245 @@
+import {
+	ExternalLink,
+	Handshake,
+	Search,
+	Sparkles,
+	Target,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteFooter } from "@/components/layout/site-footer";
+import { SiteHeader } from "@/components/layout/site-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	getOpportunityDirectoryEntries,
+	getOpportunityDirectorySummary,
+	type OpportunityDirectoryEntry,
+} from "@/lib/opportunities-directory";
+import { sanitizeImageUrl } from "@/lib/utils";
+
+export const metadata: Metadata = {
+	title: "Programas y Grants | Peru Agentic Builder Index",
+	description:
+		"Directorio publico de aceleradoras, incubadoras, fondos y programas para builders en Peru.",
+};
+
+export const dynamic = "force-dynamic";
+
+interface OpportunitiesPageProps {
+	searchParams: Promise<{
+		search?: string;
+	}>;
+}
+
+export default async function OpportunitiesPage({
+	searchParams,
+}: OpportunitiesPageProps) {
+	const params = await searchParams;
+	const search = params.search?.trim() || undefined;
+	const [summary, opportunities] = await Promise.all([
+		getOpportunityDirectorySummary(),
+		getOpportunityDirectoryEntries({ search }),
+	]);
+
+	return (
+		<div className="flex min-h-screen flex-col bg-background">
+			<SiteHeader />
+
+			<main className="flex-1">
+				<section className="border-b">
+					<div className="mx-auto max-w-screen-xl px-4 py-8 lg:px-8">
+						<div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-end">
+							<div className="space-y-4">
+								<div className="space-y-3">
+									<Badge variant="outline" className="gap-2 rounded-none">
+										<Handshake className="size-3.5" />
+										Programas
+									</Badge>
+									<h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+										Programas, grants e inversión
+									</h1>
+									<p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+										Directorio de incubadoras, aceleradoras, fondos, redes de
+										ángeles e iniciativas de innovación abierta que ayudan a
+										builders peruanos a conseguir soporte, capital o
+										distribución.
+									</p>
+								</div>
+
+								<form action="/opportunities" className="flex max-w-md gap-2">
+									<div className="flex h-9 flex-1 items-center gap-2 border bg-background px-3">
+										<Search className="size-4 text-muted-foreground" />
+										<input
+											type="search"
+											name="search"
+											defaultValue={search}
+											placeholder="Buscar programa o fondo"
+											className="h-full min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+										/>
+									</div>
+									<Button type="submit" size="sm">
+										Buscar
+									</Button>
+								</form>
+							</div>
+
+							<div className="grid grid-cols-2 border bg-card">
+								<SummaryMetric label="programas" value={summary.total} />
+								<SummaryMetric label="incubadoras" value={summary.incubators} />
+								<SummaryMetric
+									label="aceleradoras"
+									value={summary.accelerators}
+								/>
+								<SummaryMetric label="fondos" value={summary.investors} />
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section className="mx-auto max-w-screen-xl px-4 py-6 lg:px-8">
+					<div className="mb-4 flex items-center justify-between gap-4">
+						<div>
+							<h2 className="text-sm font-semibold">
+								{search ? "Resultados" : "Oportunidades mapeadas"}
+							</h2>
+							<p className="mt-1 text-xs text-muted-foreground">
+								{opportunities.length} organizaciones derivadas del mapa del
+								ecosistema.
+							</p>
+						</div>
+						{search && (
+							<Button asChild variant="outline" size="sm">
+								<Link href="/opportunities">Limpiar búsqueda</Link>
+							</Button>
+						)}
+					</div>
+
+					{opportunities.length > 0 ? (
+						<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+							{opportunities.map((opportunity) => (
+								<OpportunityCard
+									key={opportunity.id}
+									opportunity={opportunity}
+								/>
+							))}
+						</div>
+					) : (
+						<div className="border bg-card p-8 text-center">
+							<p className="text-sm font-medium">No encontramos programas.</p>
+							<p className="mt-1 text-sm text-muted-foreground">
+								Prueba con otro término o vuelve al directorio completo.
+							</p>
+						</div>
+					)}
+				</section>
+			</main>
+
+			<SiteFooter />
+		</div>
+	);
+}
+
+function SummaryMetric({ label, value }: { label: string; value: number }) {
+	return (
+		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0">
+			<div className="text-2xl font-semibold tracking-tight">
+				{new Intl.NumberFormat("es-PE").format(value)}
+			</div>
+			<div className="mt-1 text-xs text-muted-foreground">{label}</div>
+		</div>
+	);
+}
+
+function OpportunityCard({
+	opportunity,
+}: {
+	opportunity: OpportunityDirectoryEntry;
+}) {
+	const logoUrl = sanitizeImageUrl(opportunity.logoUrl);
+	const location = [opportunity.city, opportunity.department]
+		.filter(Boolean)
+		.join(", ");
+
+	return (
+		<article className="flex min-h-64 flex-col border bg-card p-4">
+			<div className="flex items-start gap-3">
+				<div className="relative flex size-12 shrink-0 items-center justify-center overflow-hidden border bg-muted text-sm font-semibold text-muted-foreground">
+					{logoUrl ? (
+						<img
+							src={logoUrl}
+							alt={opportunity.name}
+							loading="lazy"
+							decoding="async"
+							className="h-full w-full object-cover"
+						/>
+					) : (
+						getInitials(opportunity.name)
+					)}
+				</div>
+				<div className="min-w-0 flex-1">
+					<h3 className="line-clamp-2 text-sm font-semibold">
+						{opportunity.name}
+					</h3>
+					<div className="mt-2 flex flex-wrap items-center gap-2">
+						<Badge variant="secondary" className="h-5 rounded-none text-[10px]">
+							{opportunity.categoryLabel}
+						</Badge>
+						<Badge variant="outline" className="h-5 rounded-none text-[10px]">
+							{opportunity.typeLabel}
+						</Badge>
+					</div>
+				</div>
+			</div>
+
+			<p className="mt-4 line-clamp-4 text-xs leading-5 text-muted-foreground">
+				{opportunity.description || "Programa del ecosistema peruano."}
+			</p>
+
+			<div className="mt-auto border-t pt-3">
+				<div className="mb-3 grid grid-cols-2 gap-2 text-xs">
+					<div className="border p-2">
+						<div className="flex items-center gap-1.5 font-medium">
+							<Target className="size-3.5" />
+							{location || "Perú"}
+						</div>
+						<div className="mt-0.5 text-muted-foreground">ubicación</div>
+					</div>
+					<div className="border p-2">
+						<div className="flex items-center gap-1.5 font-medium">
+							<Sparkles className="size-3.5" />
+							{opportunity.isVerified ? "verificado" : "por curar"}
+						</div>
+						<div className="mt-0.5 text-muted-foreground">estado</div>
+					</div>
+				</div>
+				<div className="flex gap-2">
+					<Button asChild variant="outline" size="sm" className="flex-1">
+						<Link href={`/c/${opportunity.slug}`}>Perfil</Link>
+					</Button>
+					{opportunity.websiteUrl && (
+						<Button asChild size="sm" className="flex-1 gap-2">
+							<a
+								href={opportunity.websiteUrl}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Web
+								<ExternalLink className="size-3.5" />
+							</a>
+						</Button>
+					)}
+				</div>
+			</div>
+		</article>
+	);
+}
+
+function getInitials(name: string) {
+	return name
+		.split(/\s+/)
+		.filter(Boolean)
+		.slice(0, 2)
+		.map((part) => part.charAt(0).toUpperCase())
+		.join("");
+}

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -31,6 +31,7 @@ import {
 	getEventTypeLabel,
 	getEventUrl,
 } from "@/lib/event-utils";
+import { getOpportunityDirectorySummary } from "@/lib/opportunities-directory";
 import { sanitizeImageUrl } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -112,7 +113,6 @@ async function getIndexData() {
 				eventsCount: count(events.id),
 				upcomingEvents: sql<number>`count(*) filter (where ${events.endDate} is null or ${events.endDate} >= now())`,
 				hackathons: sql<number>`count(*) filter (where ${events.eventType} in ('hackathon', 'competition', 'olympiad', 'robotics'))`,
-				opportunities: sql<number>`count(*) filter (where ${events.eventType} in ('accelerator', 'incubator', 'fellowship', 'call_for_papers'))`,
 				cities: sql<number>`count(distinct ${events.city}) filter (where ${events.city} is not null)`,
 			})
 			.from(events)
@@ -183,26 +183,30 @@ async function getIndexData() {
 			.limit(4),
 	]);
 
-	const [[{ totalCommunities }], builderSummary, [{ totalLabs }]] =
-		await Promise.all([
-			db
-				.select({ totalCommunities: count(organizations.id) })
-				.from(organizations)
-				.where(publicOrgWhere),
-			getBuilderDirectorySummary(),
-			db
-				.select({ totalLabs: count(organizations.id) })
-				.from(organizations)
-				.where(
-					and(publicOrgWhere, inArray(organizations.type, UNIVERSITY_TYPES)),
-				),
-		]);
+	const [
+		[{ totalCommunities }],
+		builderSummary,
+		opportunitySummary,
+		[{ totalLabs }],
+	] = await Promise.all([
+		db
+			.select({ totalCommunities: count(organizations.id) })
+			.from(organizations)
+			.where(publicOrgWhere),
+		getBuilderDirectorySummary(),
+		getOpportunityDirectorySummary(),
+		db
+			.select({ totalLabs: count(organizations.id) })
+			.from(organizations)
+			.where(
+				and(publicOrgWhere, inArray(organizations.type, UNIVERSITY_TYPES)),
+			),
+	]);
 
 	const counts = countRows[0] || {
 		eventsCount: 0,
 		upcomingEvents: 0,
 		hackathons: 0,
-		opportunities: 0,
 		cities: 0,
 	};
 
@@ -216,7 +220,7 @@ async function getIndexData() {
 			events: Number(counts.eventsCount || 0),
 			upcoming: Number(counts.upcomingEvents || 0),
 			hackathons: Number(counts.hackathons || 0),
-			opportunities: Number(counts.opportunities || 0),
+			opportunities: opportunitySummary.total,
 			cities: Number(counts.cities || 0),
 			communities: Number(totalCommunities || 0),
 			builders: builderSummary.builders,
@@ -330,11 +334,11 @@ export default async function HomePage() {
 								helper="por verificar"
 							/>
 							<FacetLink
-								href="/events?country=PE&eventType=accelerator,incubator,fellowship,call_for_papers"
+								href="/opportunities"
 								icon={BookOpen}
 								label="Grants y programas"
 								value={data.counts.opportunities}
-								helper="oportunidades"
+								helper="directorio"
 							/>
 							<FacetLink
 								href="/builders"

--- a/app/(seo)/sitemap.ts
+++ b/app/(seo)/sitemap.ts
@@ -74,6 +74,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/opportunities`,
+			lastModified: new Date(),
+			changeFrequency: "daily",
+			priority: 0.8,
+		},
+		{
 			url: `${baseUrl}/data-health`,
 			lastModified: new Date(),
 			changeFrequency: "daily",

--- a/components/layout/main-nav.tsx
+++ b/components/layout/main-nav.tsx
@@ -7,6 +7,7 @@ const navItems = [
 	{ href: "/events", label: "Eventos" },
 	{ href: "/c/discover", label: "Comunidades" },
 	{ href: "/builders", label: "Builders" },
+	{ href: "/opportunities", label: "Programas" },
 	{ href: "/roadmap", label: "Roadmap" },
 ];
 

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -12,6 +12,7 @@ const navItems = [
 	{ href: "/events", label: "Eventos" },
 	{ href: "/c/discover", label: "Comunidades" },
 	{ href: "/builders", label: "Builders" },
+	{ href: "/opportunities", label: "Programas" },
 ];
 
 const secondaryItems = [

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -45,6 +45,12 @@ export function SiteFooter() {
 									>
 										Builders
 									</Link>
+									<Link
+										href="/opportunities"
+										className="hover:text-foreground transition-colors"
+									>
+										Programas
+									</Link>
 								</nav>
 							</div>
 

--- a/components/search-command.tsx
+++ b/components/search-command.tsx
@@ -5,6 +5,7 @@ import {
 	Calendar,
 	Command,
 	Database,
+	Handshake,
 	MapPin,
 	Sparkles,
 	Users,
@@ -116,6 +117,12 @@ export function SearchCommand({ hackathons }: SearchCommandProps) {
 					>
 						<Users className="mr-2 h-4 w-4" />
 						Explorar builders y hosts
+					</CommandItem>
+					<CommandItem
+						onSelect={() => runCommand(() => router.push("/opportunities"))}
+					>
+						<Handshake className="mr-2 h-4 w-4" />
+						Ver programas y grants
 					</CommandItem>
 					<CommandItem
 						onSelect={() => runCommand(() => router.push("/data-health"))}

--- a/lib/index-data-health.ts
+++ b/lib/index-data-health.ts
@@ -16,6 +16,7 @@ import {
 	EVENT_TYPE_LABELS,
 	ORGANIZER_TYPE_LABELS,
 } from "@/lib/db/schema/constants";
+import { getOpportunityDirectorySummary } from "@/lib/opportunities-directory";
 
 const PERU = "PE";
 const HACKATHON_TYPES = [
@@ -23,12 +24,6 @@ const HACKATHON_TYPES = [
 	"competition",
 	"olympiad",
 	"robotics",
-] as const;
-const OPPORTUNITY_TYPES = [
-	"accelerator",
-	"incubator",
-	"fellowship",
-	"call_for_papers",
 ] as const;
 const UNIVERSITY_TYPES = ["university", "student_org"] as const;
 
@@ -122,6 +117,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 		[eventCounts],
 		[organizationCounts],
 		builderSummary,
+		opportunitySummary,
 		[membershipCounts],
 		[sponsorCounts],
 		[relationshipCounts],
@@ -138,7 +134,6 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 				eventsCount: count(events.id),
 				upcomingEvents: sql<number>`count(*) filter (where ${events.endDate} is null or ${events.endDate} >= now())::int`,
 				hackathons: sql<number>`count(*) filter (where ${events.eventType} in ('hackathon', 'competition', 'olympiad', 'robotics'))::int`,
-				opportunities: sql<number>`count(*) filter (where ${events.eventType} in ('accelerator', 'incubator', 'fellowship', 'call_for_papers'))::int`,
 				cities: sql<number>`count(distinct ${events.city}) filter (where ${events.city} is not null and btrim(${events.city}) <> '')::int`,
 				updatedAt: sql<Date | null>`max(${events.updatedAt})`,
 				latestSourceScrapedAt: sql<Date | null>`max(${events.sourceScrapedAt})`,
@@ -156,6 +151,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			.from(organizations)
 			.where(publicOrgWhere),
 		getBuilderDirectorySummary(),
+		getOpportunityDirectorySummary(),
 		db
 			.select({
 				importedMemberships: count(communityMembers.id),
@@ -249,7 +245,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 	const totalEvents = toNumber(eventCounts?.eventsCount);
 	const totalOrganizations = toNumber(organizationCounts?.totalOrganizations);
 	const hackathons = toNumber(eventCounts?.hackathons);
-	const opportunities = toNumber(eventCounts?.opportunities);
+	const opportunities = opportunitySummary.total;
 	const labs = toNumber(organizationCounts?.labs);
 	const builders = toNumber(builderSummary.builders);
 
@@ -303,9 +299,9 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			label: "Grants y programas",
 			count: opportunities,
 			status: statusFor(opportunities),
-			href: "/events?country=PE&eventType=accelerator,incubator,fellowship,call_for_papers",
-			source: "events.event_type",
-			evidence: OPPORTUNITY_TYPES.join(", "),
+			href: "/opportunities",
+			source: "organizations",
+			evidence: `${opportunitySummary.incubators} incubadoras, ${opportunitySummary.accelerators} aceleradoras, ${opportunitySummary.investors} fondos`,
 			nextAction:
 				"Importar becas, grants, incubadoras, aceleradoras y convocatorias abiertas.",
 		},

--- a/lib/opportunities-directory.ts
+++ b/lib/opportunities-directory.ts
@@ -1,0 +1,205 @@
+import { asc } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { organizations } from "@/lib/db/schema";
+import { ORGANIZER_TYPE_LABELS } from "@/lib/db/schema/constants";
+
+export type OpportunityCategory =
+	| "accelerator"
+	| "incubator"
+	| "investor"
+	| "open_innovation"
+	| "startup_program";
+
+export type OpportunityDirectoryEntry = {
+	id: string;
+	slug: string;
+	name: string;
+	description: string | null;
+	type: string | null;
+	typeLabel: string;
+	category: OpportunityCategory;
+	categoryLabel: string;
+	city: string | null;
+	department: string | null;
+	websiteUrl: string | null;
+	logoUrl: string | null;
+	isVerified: boolean | null;
+};
+
+export type OpportunityDirectorySummary = {
+	total: number;
+	accelerators: number;
+	incubators: number;
+	investors: number;
+	openInnovation: number;
+	withWebsite: number;
+};
+
+type RawOpportunityOrganization = typeof organizations.$inferSelect;
+
+const CATEGORY_LABELS: Record<OpportunityCategory, string> = {
+	accelerator: "Aceleradora",
+	incubator: "Incubadora",
+	investor: "Fondo / inversión",
+	open_innovation: "Innovación abierta",
+	startup_program: "Programa startup",
+};
+
+const OPPORTUNITY_TERMS = [
+	"aceleración",
+	"aceleracion",
+	"aceleradora",
+	"capital",
+	"corporate venture capital",
+	"fondo de inversión",
+	"fondo de inversion",
+	"incubación",
+	"incubacion",
+	"incubadora",
+	"innovación abierta",
+	"innovacion abierta",
+	"pre-incubación",
+	"pre-incubacion",
+	"red ángel",
+	"red angel",
+	"venture",
+];
+
+function normalize(value: string | null | undefined) {
+	return (value || "")
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.toLowerCase();
+}
+
+function searchableText(org: RawOpportunityOrganization) {
+	return normalize([org.name, org.displayName, org.description].join(" "));
+}
+
+function getOpportunityCategory(
+	org: RawOpportunityOrganization,
+): OpportunityCategory | null {
+	const text = searchableText(org);
+
+	if (org.type === "investor" || text.includes("fondo de inversion")) {
+		return "investor";
+	}
+	if (text.includes("aceleracion") || text.includes("aceleradora")) {
+		return "accelerator";
+	}
+	if (
+		text.includes("incubacion") ||
+		text.includes("incubadora") ||
+		text.includes("pre-incubacion")
+	) {
+		return "incubator";
+	}
+	if (text.includes("innovacion abierta")) {
+		return "open_innovation";
+	}
+	if (text.includes("startup") || text.includes("venture")) {
+		return "startup_program";
+	}
+
+	return null;
+}
+
+function isOpportunityOrg(org: RawOpportunityOrganization) {
+	const text = searchableText(org);
+	return (
+		org.country === "PE" &&
+		(org.type === "investor" ||
+			OPPORTUNITY_TERMS.some((term) => text.includes(term)))
+	);
+}
+
+function toEntry(
+	org: RawOpportunityOrganization,
+): OpportunityDirectoryEntry | null {
+	const category = getOpportunityCategory(org);
+	if (!category) return null;
+
+	return {
+		id: org.id,
+		slug: org.slug,
+		name: org.displayName || org.name,
+		description: org.description,
+		type: org.type,
+		typeLabel: org.type
+			? ORGANIZER_TYPE_LABELS[org.type] || org.type
+			: "Organización",
+		category,
+		categoryLabel: CATEGORY_LABELS[category],
+		city: org.city,
+		department: org.department,
+		websiteUrl: org.websiteUrl,
+		logoUrl: org.logoUrl,
+		isVerified: org.isVerified,
+	};
+}
+
+async function getOpportunityOrganizations() {
+	const rows = await db
+		.select()
+		.from(organizations)
+		.orderBy(asc(organizations.name));
+
+	return rows
+		.filter(
+			(org) =>
+				org.isPublic === true &&
+				org.isPersonalOrg === false &&
+				isOpportunityOrg(org),
+		)
+		.map(toEntry)
+		.filter((entry): entry is OpportunityDirectoryEntry => Boolean(entry));
+}
+
+export async function getOpportunityDirectorySummary(): Promise<OpportunityDirectorySummary> {
+	const entries = await getOpportunityOrganizations();
+
+	return {
+		total: entries.length,
+		accelerators: entries.filter((entry) => entry.category === "accelerator")
+			.length,
+		incubators: entries.filter((entry) => entry.category === "incubator")
+			.length,
+		investors: entries.filter((entry) => entry.category === "investor").length,
+		openInnovation: entries.filter(
+			(entry) => entry.category === "open_innovation",
+		).length,
+		withWebsite: entries.filter((entry) => Boolean(entry.websiteUrl)).length,
+	};
+}
+
+export async function getOpportunityDirectoryEntries({
+	search,
+	limit = 96,
+}: {
+	search?: string;
+	limit?: number;
+} = {}) {
+	const entries = await getOpportunityOrganizations();
+	const query = normalize(search);
+
+	return entries
+		.filter((entry) => {
+			if (!query) return true;
+			return normalize(
+				[
+					entry.name,
+					entry.description,
+					entry.typeLabel,
+					entry.categoryLabel,
+					entry.city,
+					entry.department,
+				].join(" "),
+			).includes(query);
+		})
+		.sort((a, b) => {
+			if (a.isVerified !== b.isVerified) return a.isVerified ? -1 : 1;
+			if (a.websiteUrl !== b.websiteUrl) return a.websiteUrl ? -1 : 1;
+			return a.name.localeCompare(b.name);
+		})
+		.slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- adds a public /opportunities directory for Peru programs, incubators, accelerators and investors
- powers the Grants y programas facet from organizations instead of event types
- wires the page into nav, sitemap, footer, search command and data health

## Verification
- bunx biome check --write app/(landing)/opportunities/page.tsx app/(landing)/page.tsx app/(seo)/sitemap.ts components/layout/main-nav.tsx components/layout/mobile-nav.tsx components/layout/site-footer.tsx components/search-command.tsx lib/index-data-health.ts lib/opportunities-directory.ts
- bun --bun tsc --noEmit --pretty false
- git diff --check
- bun run build
- local browser smoke test for /opportunities on desktop and mobile