### PR TITLE
fix: clarify coverage surface

### DIFF
--- a/app/(landing)/data-health/page.tsx
+++ b/app/(landing)/data-health/page.tsx
@@ -3,7 +3,6 @@ import {
 	AlertTriangle,
 	ArrowRight,
 	CheckCircle2,
-	CircleDashed,
 	Database,
 	ExternalLink,
 	ListChecks,
@@ -24,7 +23,7 @@ import {
 } from "@/lib/index-data-health";
 
 export const metadata: Metadata = {
-	title: "Data Health | Peru Agentic Builder Index",
+	title: "Cobertura | Peru Agentic Builder Index",
 	description:
 		"Cobertura, fuentes y gaps actuales del Peru Agentic Builder Index.",
 };
@@ -86,16 +85,16 @@ export default async function DataHealthPage() {
 							<div className="max-w-3xl space-y-5">
 								<Badge variant="outline" className="gap-2 rounded-none">
 									<Database className="size-3.5" />
-									Data health
+									Cobertura
 								</Badge>
 								<div className="space-y-3">
 									<h1 className="text-3xl font-semibold tracking-tight sm:text-5xl">
-										Cobertura del Peru Agentic Builder Index
+										Cobertura y gaps del Peru Agentic Builder Index
 									</h1>
 									<p className="max-w-2xl text-base leading-7 text-muted-foreground">
-										Vista pública de lo que ya está mapeado, qué viene de datos
-										reales y qué todavía necesita backfill antes del primer
-										State of Agentic Builders in Peru.
+										Vista operativa de lo que ya está mapeado, qué viene de
+										datos reales y qué necesita backfill para priorizar el
+										trabajo del índice.
 									</p>
 								</div>
 								<div className="flex flex-col gap-2 sm:flex-row">
@@ -149,13 +148,20 @@ export default async function DataHealthPage() {
 					<div className="space-y-8">
 						<SectionHeader
 							icon={ListChecks}
-							title="Backfill queue"
+							title="Backfill prioritario"
 							description="Trabajo pendiente ordenado por gaps reales del modelo actual."
 						/>
 						<div className="grid gap-3">
-							{backfillQueue.map((facet) => (
-								<BackfillRow key={facet.id} facet={facet} />
-							))}
+							{backfillQueue.length > 0 ? (
+								backfillQueue.map((facet) => (
+									<BackfillRow key={facet.id} facet={facet} />
+								))
+							) : (
+								<div className="border bg-card p-6 text-sm text-muted-foreground">
+									Los buckets principales ya tienen modelo y conteo. El trabajo
+									urgente está en calidad de datos y fuentes.
+								</div>
+							)}
 						</div>
 
 						<SectionHeader
@@ -280,11 +286,7 @@ function BackfillRow({ facet }: { facet: CoverageFacet }) {
 		<div className="grid gap-4 border bg-card p-4 md:grid-cols-[180px_minmax(0,1fr)]">
 			<div className="space-y-2">
 				<div className="flex items-center gap-2">
-					{facet.status === "not_modeled" ? (
-						<CircleDashed className="size-4 text-muted-foreground" />
-					) : (
-						<AlertTriangle className="size-4 text-amber-600" />
-					)}
+					<AlertTriangle className="size-4 text-amber-600" />
 					<h3 className="text-sm font-semibold">{facet.label}</h3>
 				</div>
 				<Badge className={`rounded-none ${status.className}`}>

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -6,8 +6,6 @@ import {
 	Code2,
 	ExternalLink,
 	FlaskConical,
-	GitBranch,
-	Lightbulb,
 	MapPin,
 	Search,
 	Sparkles,
@@ -304,7 +302,7 @@ export default async function HomePage() {
 
 				<section className="border-b bg-muted/20">
 					<div className="mx-auto max-w-screen-xl px-4 lg:px-8 py-5">
-						<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+						<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
 							<FacetLink
 								href="/events?country=PE"
 								icon={CalendarDays}
@@ -347,20 +345,6 @@ export default async function HomePage() {
 								value={data.counts.builders}
 								helper="desde eventos"
 							/>
-							<FacetLink
-								href="/roadmap"
-								icon={GitBranch}
-								label="Demo projects"
-								value={0}
-								helper="siguiente dataset"
-							/>
-							<FacetLink
-								href="/roadmap"
-								icon={Lightbulb}
-								label="AI workflows"
-								value={0}
-								helper="siguiente dataset"
-							/>
 						</div>
 					</div>
 				</section>
@@ -380,7 +364,7 @@ export default async function HomePage() {
 
 						<SectionHeader
 							title="Hackathons y retos"
-							description="Eventos que producen demos, repos y nuevos builders para el índice."
+							description="Eventos que producen proyectos, repos y nuevos builders para el índice."
 							href="/events?country=PE&eventType=hackathon,competition,olympiad,robotics"
 						/>
 						<div className="grid gap-3 md:grid-cols-2">
@@ -436,7 +420,7 @@ export default async function HomePage() {
 										</h2>
 										<p className="mt-1 text-xs leading-5 text-muted-foreground">
 											La versión trimestral debe salir de estos datos: eventos,
-											demos, comunidades, labs, sponsors y workflows.
+											comunidades, labs, programas, sponsors y builders.
 										</p>
 									</div>
 									<div className="grid grid-cols-2 gap-2 text-xs">

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -67,7 +67,7 @@ export function SiteFooter() {
 										href="/data-health"
 										className="hover:text-foreground transition-colors"
 									>
-										Data health
+										Cobertura
 									</Link>
 									<a
 										href="mailto:hey@hack0.dev"

--- a/lib/index-data-health.ts
+++ b/lib/index-data-health.ts
@@ -316,27 +316,6 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			nextAction:
 				"Dedupe manual de nombres, perfiles reclamables y links sociales.",
 		},
-		{
-			id: "demos",
-			label: "Demo projects",
-			count: 0,
-			status: statusFor(0, false),
-			href: null,
-			source: "pendiente",
-			evidence: "sin modelo público",
-			nextAction:
-				"Crear dataset mínimo: evento, demo, GitHub, equipo, video y tags.",
-		},
-		{
-			id: "workflows",
-			label: "AI workflows",
-			count: 0,
-			status: statusFor(0, false),
-			href: null,
-			source: "pendiente",
-			evidence: "sin modelo público",
-			nextAction: "Curar workflows reutilizables desde demos y eventos de IA.",
-		},
 	];
 
 	const sourceBreakdown = sourceRows.map((row) => ({


### PR DESCRIPTION
## Summary
- removes speculative demo/workflow buckets from the public index surface
- renames the data-health UI copy to Cobertura so it reads as an ops coverage dashboard
- keeps the home index focused on active modeled buckets: events, communities, hackathons, labs, programs and builders

## Verification
- bun -e getIndexDataHealth() returns 6 live facets and no demo/workflow buckets
- bunx biome check --write app/(landing)/page.tsx app/(landing)/data-health/page.tsx components/layout/site-footer.tsx lib/index-data-health.ts
- bun --bun tsc --noEmit --pretty false
- bun run db:migrate
- bun run build
- curl / and /data-health return 200; /demos and /workflows return 404
- agent-browser smoke test on /data-health