### PR TITLE
feat: make index LATAM-first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-hack0.dev is the public Peru Agentic Builder Index. It maps events, communities, hackathons, labs, grants, builders, demo projects, and useful AI workflows in Peru, with Luma imports as the primary event pipeline.
+hack0.dev is the public LATAM Agentic Builder Index. It maps events, communities, hackathons, labs, grants, and builders across Latin America, with Luma imports as the primary event pipeline.
 
 ## Commands
 
@@ -33,7 +33,7 @@ bun run sync:luma    # Backfill/sync the Luma calendar
 ### Key Directories
 
 - `app/` - Next.js App Router pages
-  - `(landing)/page.tsx` - Peru Agentic Builder Index homepage
+  - `(landing)/page.tsx` - LATAM Agentic Builder Index homepage
   - `events/` - Public event listing
   - `(app)/e/[code]/page.tsx` - Event detail page
   - `(app)/c/` - Community and organization directory

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### hack0.dev
-Hackathons & Tech Events in Peru 🇵🇪
+Hackathons, communities, and tech events in LATAM
 
 ## Contributing
 

--- a/app/(app)/api/events/route.ts
+++ b/app/(app)/api/events/route.ts
@@ -1,10 +1,46 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getEvents } from "@/lib/actions/events";
+import { loadSearchParams } from "@/lib/search-params";
 
-export async function GET() {
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+function parseLimit(value: string | null) {
+	const parsed = Number.parseInt(value || "", 10);
+	if (!Number.isFinite(parsed)) return DEFAULT_LIMIT;
+	return Math.min(Math.max(parsed, 1), MAX_LIMIT);
+}
+
+export async function GET(request: NextRequest) {
 	try {
-		const result = await getEvents({ limit: 50 });
-		return NextResponse.json({ events: result.events });
+		const rawParams = Object.fromEntries(request.nextUrl.searchParams);
+		const params = await loadSearchParams(rawParams);
+		const hasTimeFilter = request.nextUrl.searchParams.has("timeFilter");
+		const result = await getEvents({
+			category: params.category,
+			search: params.search,
+			eventType: params.eventType,
+			organizerType: params.organizerType,
+			skillLevel: params.skillLevel,
+			format: params.format,
+			status: params.status,
+			domain: params.domain,
+			country: params.country,
+			department: params.department,
+			juniorFriendly: params.juniorFriendly,
+			mine: params.mine,
+			page: params.page,
+			limit: parseLimit(request.nextUrl.searchParams.get("limit")),
+			timeFilter: hasTimeFilter ? params.timeFilter : "upcoming",
+		});
+
+		return NextResponse.json({
+			events: result.events,
+			total: result.total,
+			page: result.page,
+			totalPages: result.totalPages,
+			hasMore: result.hasMore,
+		});
 	} catch (error) {
 		console.error("Error fetching events:", error);
 		return NextResponse.json({ events: [] }, { status: 500 });

--- a/app/(app)/api/og/route.tsx
+++ b/app/(app)/api/og/route.tsx
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
 		const location =
 			event.format === "virtual"
 				? "Virtual"
-				: event.department || event.city || "Perú";
+				: event.department || event.city || "LATAM";
 
 		const dateStr = startDate
 			? formatEventDateSmart(startDate)

--- a/app/(app)/c/discover/page.tsx
+++ b/app/(app)/c/discover/page.tsx
@@ -44,7 +44,7 @@ interface DiscoverPageProps {
 export const metadata = {
 	title: "Explorar Comunidades | hack0",
 	description:
-		"Descubre comunidades de tecnología, hackathons y eventos en Perú. Únete a la comunidad tech más activa.",
+		"Descubre comunidades de tecnología, hackathons y eventos en LATAM. Únete al mapa regional de builders.",
 };
 
 export const dynamic = "force-dynamic";

--- a/app/(landing)/builders/page.tsx
+++ b/app/(landing)/builders/page.tsx
@@ -14,9 +14,9 @@ import { formatEventDate } from "@/lib/event-utils";
 import { sanitizeImageUrl } from "@/lib/utils";
 
 export const metadata: Metadata = {
-	title: "Builders y Hosts | Peru Agentic Builder Index",
+	title: "Builders y Hosts | LATAM Agentic Builder Index",
 	description:
-		"Directorio publico de builders y hosts activos en eventos de IA, hackathons y comunidades tech en Peru.",
+		"Directorio publico de builders y hosts activos en eventos de IA, hackathons y comunidades tech en LATAM.",
 };
 
 export const dynamic = "force-dynamic";
@@ -47,12 +47,12 @@ export default async function BuildersPage({
 						<div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
 							<div className="space-y-4">
 								<div className="space-y-3">
-									<h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+									<h1 className="text-3xl font-semibold sm:text-4xl">
 										Builders y hosts
 									</h1>
 									<p className="max-w-2xl text-sm leading-6 text-muted-foreground">
 										Personas que aparecen como hosts en eventos publicos del
-										Peru Agentic Builder Index. Es una senal practica de quien
+										LATAM Agentic Builder Index. Es una senal practica de quien
 										organiza, ensena, convoca o mueve comunidades.
 									</p>
 								</div>
@@ -132,7 +132,7 @@ export default async function BuildersPage({
 function SummaryMetric({ label, value }: { label: string; value: number }) {
 	return (
 		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0">
-			<div className="text-2xl font-semibold tracking-tight">
+			<div className="text-2xl font-semibold">
 				{new Intl.NumberFormat("es-PE").format(value)}
 			</div>
 			<div className="mt-1 text-xs text-muted-foreground">{label}</div>

--- a/app/(landing)/data-health/page.tsx
+++ b/app/(landing)/data-health/page.tsx
@@ -23,9 +23,9 @@ import {
 } from "@/lib/index-data-health";
 
 export const metadata: Metadata = {
-	title: "Cobertura | Peru Agentic Builder Index",
+	title: "Cobertura | LATAM Agentic Builder Index",
 	description:
-		"Cobertura, fuentes y gaps actuales del Peru Agentic Builder Index.",
+		"Cobertura, fuentes y gaps actuales del LATAM Agentic Builder Index.",
 };
 
 export const dynamic = "force-dynamic";
@@ -88,8 +88,8 @@ export default async function DataHealthPage() {
 									Cobertura
 								</Badge>
 								<div className="space-y-3">
-									<h1 className="text-3xl font-semibold tracking-tight sm:text-5xl">
-										Cobertura y gaps del Peru Agentic Builder Index
+									<h1 className="text-3xl font-semibold sm:text-5xl">
+										Cobertura y gaps del LATAM Agentic Builder Index
 									</h1>
 									<p className="max-w-2xl text-base leading-7 text-muted-foreground">
 										Vista operativa de lo que ya está mapeado, qué viene de
@@ -99,13 +99,13 @@ export default async function DataHealthPage() {
 								</div>
 								<div className="flex flex-col gap-2 sm:flex-row">
 									<Button asChild size="sm" className="gap-2">
-										<Link href="/events?country=PE">
+										<Link href="/events">
 											Ver eventos
 											<ArrowRight className="size-4" />
 										</Link>
 									</Button>
 									<Button asChild variant="outline" size="sm" className="gap-2">
-										<a href="mailto:hey@hack0.dev?subject=Actualizar%20Peru%20Agentic%20Builder%20Index">
+										<a href="mailto:hey@hack0.dev?subject=Actualizar%20LATAM%20Agentic%20Builder%20Index">
 											Reportar dataset
 											<ExternalLink className="size-4" />
 										</a>
@@ -212,11 +212,7 @@ function HeroMetric({
 	return (
 		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0">
 			<div
-				className={
-					text
-						? "text-sm font-semibold tracking-tight"
-						: "text-2xl font-semibold tracking-tight"
-				}
+				className={text ? "text-sm font-semibold" : "text-2xl font-semibold"}
 			>
 				{typeof value === "number" ? formatNumber(value) : value}
 			</div>
@@ -232,7 +228,7 @@ function CoverageCard({ facet }: { facet: CoverageFacet }) {
 			<div className="space-y-3">
 				<div className="flex items-start justify-between gap-3">
 					<div>
-						<div className="text-2xl font-semibold tracking-tight">
+						<div className="text-2xl font-semibold">
 							{formatNumber(facet.count)}
 						</div>
 						<h2 className="mt-1 text-sm font-medium">{facet.label}</h2>
@@ -272,7 +268,7 @@ function SectionHeader({
 				<Icon className="size-4" />
 			</div>
 			<div>
-				<h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+				<h2 className="text-xl font-semibold">{title}</h2>
 				<p className="mt-1 text-sm text-muted-foreground">{description}</p>
 			</div>
 		</div>
@@ -319,7 +315,7 @@ function QualityCard({ signal }: { signal: QualitySignal }) {
 				<CheckCircle2 className={`size-4 ${severityCopy[signal.severity]}`} />
 			</div>
 			<div className="mt-4 flex items-end justify-between gap-3">
-				<div className="text-2xl font-semibold tracking-tight">
+				<div className="text-2xl font-semibold">
 					{formatNumber(signal.value)}
 				</div>
 				<div className="text-xs text-muted-foreground">

--- a/app/(landing)/opportunities/page.tsx
+++ b/app/(landing)/opportunities/page.tsx
@@ -19,9 +19,9 @@ import {
 import { sanitizeImageUrl } from "@/lib/utils";
 
 export const metadata: Metadata = {
-	title: "Programas y Grants | Peru Agentic Builder Index",
+	title: "Programas y Grants | LATAM Agentic Builder Index",
 	description:
-		"Directorio publico de aceleradoras, incubadoras, fondos y programas para builders en Peru.",
+		"Directorio publico de aceleradoras, incubadoras, fondos y programas para builders en LATAM.",
 };
 
 export const dynamic = "force-dynamic";
@@ -56,13 +56,13 @@ export default async function OpportunitiesPage({
 										<Handshake className="size-3.5" />
 										Programas
 									</Badge>
-									<h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+									<h1 className="text-3xl font-semibold sm:text-4xl">
 										Programas, grants e inversión
 									</h1>
 									<p className="max-w-2xl text-sm leading-6 text-muted-foreground">
 										Directorio de incubadoras, aceleradoras, fondos, redes de
 										ángeles e iniciativas de innovación abierta que ayudan a
-										builders peruanos a conseguir soporte, capital o
+										builders de Latinoamérica a conseguir soporte, capital o
 										distribución.
 									</p>
 								</div>
@@ -143,7 +143,7 @@ export default async function OpportunitiesPage({
 function SummaryMetric({ label, value }: { label: string; value: number }) {
 	return (
 		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0">
-			<div className="text-2xl font-semibold tracking-tight">
+			<div className="text-2xl font-semibold">
 				{new Intl.NumberFormat("es-PE").format(value)}
 			</div>
 			<div className="mt-1 text-xs text-muted-foreground">{label}</div>
@@ -201,7 +201,7 @@ function OpportunityCard({
 					<div className="border p-2">
 						<div className="flex items-center gap-1.5 font-medium">
 							<Target className="size-3.5" />
-							{location || "Perú"}
+							{location || "LATAM"}
 						</div>
 						<div className="mt-0.5 text-muted-foreground">ubicación</div>
 					</div>

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -15,6 +15,7 @@ import {
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { EventCover } from "@/components/events";
 import { SiteFooter } from "@/components/layout/site-footer";
 import { SiteHeader } from "@/components/layout/site-header";
 import { Badge } from "@/components/ui/badge";
@@ -23,9 +24,15 @@ import { getEvents } from "@/lib/actions/events";
 import { getBuilderDirectorySummary } from "@/lib/builders-directory";
 import { db } from "@/lib/db";
 import { communityMembers, events, organizations } from "@/lib/db/schema";
-import { ORGANIZER_TYPE_LABELS } from "@/lib/db/schema/constants";
+import {
+	LATAM_COUNTRIES,
+	LATAM_COUNTRY_CODES,
+	ORGANIZER_TYPE_LABELS,
+} from "@/lib/db/schema/constants";
 import {
 	formatEventDateRange,
+	getCountryFlag,
+	getCountryName,
 	getEventTypeLabel,
 	getEventUrl,
 } from "@/lib/event-utils";
@@ -33,14 +40,19 @@ import { getOpportunityDirectorySummary } from "@/lib/opportunities-directory";
 import { sanitizeImageUrl } from "@/lib/utils";
 
 export const metadata: Metadata = {
-	title: "Peru Agentic Builder Index",
+	title: "LATAM Agentic Builder Index",
 	description:
-		"Directorio público de eventos, comunidades, hackathons, labs, grants y builders de IA en Perú.",
+		"Directorio público de eventos, comunidades, hackathons, labs, grants y builders de IA en Latinoamérica.",
 };
 
 export const dynamic = "force-dynamic";
 
-const PERU = "PE";
+const LATAM_EVENT_COUNTRIES = LATAM_COUNTRY_CODES.filter(
+	(code) => code !== "GLOBAL",
+);
+const LATAM_ORG_COUNTRIES = LATAM_COUNTRIES.filter(
+	(country) => country.code !== "GLOBAL",
+);
 const HACKATHON_TYPES = [
 	"hackathon",
 	"competition",
@@ -65,16 +77,23 @@ type IndexCommunity = {
 	memberCount: number;
 };
 
+type CountryCoverage = {
+	code: string;
+	name: string;
+	events: number;
+	communities: number;
+};
+
 async function getIndexData() {
 	const publicOrgWhere = and(
 		eq(organizations.isPublic, true),
 		eq(organizations.isPersonalOrg, false),
-		eq(organizations.country, PERU),
+		inArray(organizations.country, LATAM_EVENT_COUNTRIES),
 	);
 
-	const approvedPeruEventsWhere = and(
+	const approvedLatamEventsWhere = and(
 		eq(events.isApproved, true),
-		eq(events.country, PERU),
+		inArray(events.country, LATAM_EVENT_COUNTRIES),
 		isNull(events.parentEventId),
 	);
 
@@ -91,17 +110,19 @@ async function getIndexData() {
 		upcoming,
 		hackathons,
 		countRows,
+		countryEventRows,
+		countryCommunityRows,
 		communityRows,
 		labRows,
 		recentSources,
 	] = await Promise.all([
 		getEvents({
-			country: [PERU],
+			country: LATAM_EVENT_COUNTRIES,
 			timeFilter: "upcoming",
 			limit: 6,
 		}),
 		getEvents({
-			country: [PERU],
+			country: LATAM_EVENT_COUNTRIES,
 			eventType: [...HACKATHON_TYPES],
 			timeFilter: "all",
 			limit: 4,
@@ -114,7 +135,24 @@ async function getIndexData() {
 				cities: sql<number>`count(distinct ${events.city}) filter (where ${events.city} is not null)`,
 			})
 			.from(events)
-			.where(approvedPeruEventsWhere),
+			.where(approvedLatamEventsWhere),
+		db
+			.select({
+				country: events.country,
+				events: count(events.id),
+				activeEvents: sql<number>`count(*) filter (where ${events.endDate} is null or ${events.endDate} >= now())`,
+			})
+			.from(events)
+			.where(approvedLatamEventsWhere)
+			.groupBy(events.country),
+		db
+			.select({
+				country: organizations.country,
+				communities: count(organizations.id),
+			})
+			.from(organizations)
+			.where(publicOrgWhere)
+			.groupBy(organizations.country),
 		db
 			.select({
 				id: organizations.id,
@@ -175,7 +213,7 @@ async function getIndexData() {
 				count: count(events.id),
 			})
 			.from(events)
-			.where(approvedPeruEventsWhere)
+			.where(approvedLatamEventsWhere)
 			.groupBy(events.scrapeSource)
 			.orderBy(desc(count(events.id)))
 			.limit(4),
@@ -207,6 +245,32 @@ async function getIndexData() {
 		hackathons: 0,
 		cities: 0,
 	};
+	const eventCountsByCountry = new Map(
+		countryEventRows.map((row) => [
+			row.country,
+			{
+				events: Number(row.events || 0),
+				activeEvents: Number(row.activeEvents || 0),
+			},
+		]),
+	);
+	const communityCountsByCountry = new Map(
+		countryCommunityRows.map((row) => [
+			row.country,
+			Number(row.communities || 0),
+		]),
+	);
+	const countryCoverage = LATAM_ORG_COUNTRIES.map((country) => {
+		const eventCounts = eventCountsByCountry.get(country.code);
+		return {
+			code: country.code,
+			name: getCountryName(country.code),
+			events: eventCounts?.events || 0,
+			communities: communityCountsByCountry.get(country.code) || 0,
+		};
+	})
+		.filter((country) => country.events > 0 || country.communities > 0)
+		.sort((a, b) => b.events + b.communities - (a.events + a.communities));
 
 	return {
 		upcoming: upcoming.events,
@@ -214,6 +278,7 @@ async function getIndexData() {
 		communities: communityRows.map(normalizeCommunity),
 		labs: labRows.map(normalizeCommunity),
 		recentSources,
+		countryCoverage,
 		counts: {
 			events: Number(counts.eventsCount || 0),
 			upcoming: Number(counts.upcomingEvents || 0),
@@ -223,6 +288,7 @@ async function getIndexData() {
 			communities: Number(totalCommunities || 0),
 			builders: builderSummary.builders,
 			labs: Number(totalLabs || 0),
+			countries: LATAM_ORG_COUNTRIES.length,
 		},
 	};
 }
@@ -241,7 +307,7 @@ function formatNumber(value: number) {
 function locationLabel(city: string | null, department: string | null) {
 	if (city && department && city !== department)
 		return `${city}, ${department}`;
-	return city || department || "Perú";
+	return city || department || "LATAM";
 }
 
 export default async function HomePage() {
@@ -261,25 +327,25 @@ export default async function HomePage() {
 						<div className="grid gap-8 lg:grid-cols-[minmax(0,1.05fr)_420px] lg:items-end">
 							<div className="space-y-6">
 								<div className="space-y-4">
-									<h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-										Peru Agentic Builder Index
+									<h1 className="max-w-3xl text-4xl font-semibold text-foreground sm:text-5xl lg:text-6xl">
+										LATAM Agentic Builder Index
 									</h1>
 									<p className="max-w-2xl text-base leading-7 text-muted-foreground">
 										Eventos, comunidades, hackathons, labs, grants y builders de
-										IA en Perú, mantenidos desde hack0 y el calendario público
-										de la comunidad.
+										IA en Latinoamérica, mantenidos desde hack0 y calendarios
+										públicos de la comunidad.
 									</p>
 								</div>
 
 								<div className="flex flex-col gap-2 sm:flex-row">
 									<Button asChild size="sm" className="gap-2">
-										<Link href="/events?country=PE">
+										<Link href="/events">
 											Explorar eventos
 											<ArrowRight className="size-4" />
 										</Link>
 									</Button>
 									<Button asChild variant="outline" size="sm" className="gap-2">
-										<Link href="/c/discover?countries=PE">
+										<Link href="/c/discover">
 											Ver comunidades
 											<Search className="size-4" />
 										</Link>
@@ -288,63 +354,107 @@ export default async function HomePage() {
 							</div>
 
 							<div className="grid grid-cols-2 border bg-card">
-								<HeroMetric label="Eventos Perú" value={data.counts.events} />
+								<HeroMetric label="Eventos LATAM" value={data.counts.events} />
 								<HeroMetric
 									label="Comunidades"
 									value={data.counts.communities}
 								/>
 								<HeroMetric label="Hackathons" value={data.counts.hackathons} />
-								<HeroMetric label="Ciudades" value={data.counts.cities} />
+								<HeroMetric
+									label="Países soportados"
+									value={data.counts.countries}
+								/>
 							</div>
 						</div>
 					</div>
 				</section>
 
 				<section className="border-b bg-muted/20">
-					<div className="mx-auto max-w-screen-xl px-4 lg:px-8 py-5">
-						<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-							<FacetLink
-								href="/events?country=PE"
-								icon={CalendarDays}
-								label="Eventos"
-								value={data.counts.upcoming}
-								helper="upcoming"
-							/>
-							<FacetLink
-								href="/c/discover?countries=PE"
-								icon={Users}
-								label="Comunidades"
-								value={data.counts.communities}
-								helper="mapeadas"
-							/>
-							<FacetLink
-								href="/events?country=PE&eventType=hackathon,competition,olympiad,robotics"
-								icon={Zap}
-								label="Hackathons"
-								value={data.counts.hackathons}
-								helper="históricos"
-							/>
-							<FacetLink
-								href="/c/discover?countries=PE&types=university,student_org"
-								icon={FlaskConical}
-								label="Universidades y labs"
-								value={data.counts.labs}
-								helper="por verificar"
-							/>
-							<FacetLink
-								href="/opportunities"
-								icon={BookOpen}
-								label="Grants y programas"
-								value={data.counts.opportunities}
-								helper="directorio"
-							/>
-							<FacetLink
-								href="/builders"
-								icon={Code2}
-								label="Builders y hosts"
-								value={data.counts.builders}
-								helper="desde eventos"
-							/>
+					<div className="mx-auto grid max-w-screen-xl gap-4 px-4 py-6 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-start lg:px-8">
+						<div className="border bg-background p-4 sm:p-5">
+							<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+								<div className="max-w-2xl">
+									<h2 className="text-lg font-semibold">
+										El mapa operativo para builders de LATAM
+									</h2>
+									<p className="mt-1 text-sm leading-6 text-muted-foreground">
+										Un solo lugar para encontrar dónde construir, con quién
+										conectar y qué comunidades están activas por país.
+									</p>
+								</div>
+								<Button asChild variant="outline" size="sm" className="gap-2">
+									<Link href="/data-health">
+										Ver cobertura
+										<ArrowRight className="size-4" />
+									</Link>
+								</Button>
+							</div>
+							<div className="mt-5 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+								<FacetLink
+									href="/events"
+									icon={CalendarDays}
+									label="Eventos activos"
+									value={data.counts.upcoming}
+									helper="para esta temporada"
+								/>
+								<FacetLink
+									href="/c/discover"
+									icon={Users}
+									label="Comunidades"
+									value={data.counts.communities}
+									helper="mapeadas"
+								/>
+								<FacetLink
+									href="/events?eventType=hackathon,competition,olympiad,robotics"
+									icon={Zap}
+									label="Hackathons"
+									value={data.counts.hackathons}
+									helper="históricos"
+								/>
+								<FacetLink
+									href="/c/discover?types=university,student_org"
+									icon={FlaskConical}
+									label="Universidades y labs"
+									value={data.counts.labs}
+									helper="por verificar"
+								/>
+								<FacetLink
+									href="/opportunities"
+									icon={BookOpen}
+									label="Grants y programas"
+									value={data.counts.opportunities}
+									helper="directorio"
+								/>
+								<FacetLink
+									href="/builders"
+									icon={Code2}
+									label="Builders y hosts"
+									value={data.counts.builders}
+									helper="desde eventos"
+								/>
+							</div>
+						</div>
+
+						<div className="border bg-background p-4 sm:p-5">
+							<div className="flex items-center justify-between gap-4">
+								<div>
+									<h2 className="text-lg font-semibold">Países con señal</h2>
+									<p className="mt-1 text-sm text-muted-foreground">
+										Eventos y comunidades ya indexadas.
+									</p>
+								</div>
+								<div className="text-right">
+									<div className="text-2xl font-semibold">
+										{data.countryCoverage.length}
+									</div>
+									<div className="text-xs text-muted-foreground">con data</div>
+								</div>
+							</div>
+							<div className="mt-4 grid gap-2">
+								{data.countryCoverage.slice(0, 8).map((country) => (
+									<CountryCoverageRow key={country.code} country={country} />
+								))}
+							</div>
 						</div>
 					</div>
 				</section>
@@ -354,7 +464,7 @@ export default async function HomePage() {
 						<SectionHeader
 							title="Próximos eventos"
 							description="El pulso público para builders, estudiantes, founders y comunidades."
-							href="/events?country=PE"
+							href="/events"
 						/>
 						<div className="grid gap-3">
 							{data.upcoming.map((event) => (
@@ -365,7 +475,7 @@ export default async function HomePage() {
 						<SectionHeader
 							title="Hackathons y retos"
 							description="Eventos que producen proyectos, repos y nuevos builders para el índice."
-							href="/events?country=PE&eventType=hackathon,competition,olympiad,robotics"
+							href="/events?eventType=hackathon,competition,olympiad,robotics"
 						/>
 						<div className="grid gap-3 md:grid-cols-2">
 							{data.hackathons.map((event) => (
@@ -386,7 +496,7 @@ export default async function HomePage() {
 							</div>
 							<div className="border-t p-3">
 								<Button asChild variant="outline" size="sm" className="w-full">
-									<Link href="/c/discover?countries=PE">Abrir directorio</Link>
+									<Link href="/c/discover">Abrir directorio</Link>
 								</Button>
 							</div>
 						</section>
@@ -416,11 +526,12 @@ export default async function HomePage() {
 								<div className="space-y-3">
 									<div>
 										<h2 className="text-sm font-semibold">
-											State of Agentic Builders in Peru
+											State of Agentic Builders in LATAM
 										</h2>
 										<p className="mt-1 text-xs leading-5 text-muted-foreground">
 											La versión trimestral debe salir de estos datos: eventos,
-											comunidades, labs, programas, sponsors y builders.
+											comunidades, labs, programas, sponsors y builders por
+											país.
 										</p>
 									</div>
 									<div className="grid grid-cols-2 gap-2 text-xs">
@@ -455,9 +566,7 @@ export default async function HomePage() {
 function HeroMetric({ label, value }: { label: string; value: number }) {
 	return (
 		<div className="border-b border-r p-4 last:border-r-0 even:border-r-0 sm:p-5">
-			<div className="text-2xl font-semibold tracking-tight">
-				{formatNumber(value)}
-			</div>
+			<div className="text-2xl font-semibold">{formatNumber(value)}</div>
 			<div className="mt-1 text-xs text-muted-foreground">{label}</div>
 		</div>
 	);
@@ -495,6 +604,29 @@ function FacetLink({
 	);
 }
 
+function CountryCoverageRow({ country }: { country: CountryCoverage }) {
+	return (
+		<Link
+			href={`/events?country=${country.code}`}
+			className="group flex items-center justify-between border bg-card px-3 py-2.5 transition-colors hover:bg-muted/30"
+		>
+			<div className="flex min-w-0 items-center gap-3">
+				<div className="text-lg leading-none">
+					{getCountryFlag(country.code)}
+				</div>
+				<div className="min-w-0">
+					<div className="truncate text-sm font-medium">{country.name}</div>
+					<div className="text-xs text-muted-foreground">
+						{formatNumber(country.events)} eventos ·{" "}
+						{formatNumber(country.communities)} comunidades
+					</div>
+				</div>
+			</div>
+			<ArrowRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+		</Link>
+	);
+}
+
 function SectionHeader({
 	title,
 	description,
@@ -507,7 +639,7 @@ function SectionHeader({
 	return (
 		<div className="flex items-end justify-between gap-4">
 			<div>
-				<h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+				<h2 className="text-xl font-semibold">{title}</h2>
 				<p className="mt-1 text-sm text-muted-foreground">{description}</p>
 			</div>
 			<Link
@@ -527,9 +659,6 @@ function EventIndexRow({
 	event: Awaited<ReturnType<typeof getEvents>>["events"][number];
 }) {
 	const eventUrl = getEventUrl(event);
-	const imageUrl = event.eventImageUrl
-		? sanitizeImageUrl(event.eventImageUrl)
-		: null;
 
 	return (
 		<Link
@@ -537,19 +666,12 @@ function EventIndexRow({
 			className="group grid gap-4 border bg-card p-3 transition-colors hover:bg-muted/20 sm:grid-cols-[96px_minmax(0,1fr)_auto]"
 		>
 			<div className="relative aspect-[4/3] overflow-hidden bg-muted sm:aspect-square">
-				{imageUrl ? (
-					<Image
-						src={imageUrl}
-						alt={event.name}
-						fill
-						className="object-cover transition-transform group-hover:scale-105"
-						sizes="96px"
-					/>
-				) : (
-					<div className="flex h-full items-center justify-center text-muted-foreground">
-						<CalendarDays className="size-5" />
-					</div>
-				)}
+				<EventCover
+					event={event}
+					className="h-full w-full"
+					imageClassName="transition-transform group-hover:scale-105"
+					sizes="96px"
+				/>
 			</div>
 			<div className="min-w-0 space-y-2">
 				<div className="flex flex-wrap items-center gap-2">
@@ -565,7 +687,7 @@ function EventIndexRow({
 					</span>
 				</div>
 				<div>
-					<h3 className="line-clamp-2 text-base font-semibold tracking-tight group-hover:underline">
+					<h3 className="line-clamp-2 text-base font-semibold group-hover:underline">
 						{event.name}
 					</h3>
 					<p className="mt-1 line-clamp-2 text-sm leading-6 text-muted-foreground">
@@ -589,9 +711,6 @@ function EventCompactCard({
 	event: Awaited<ReturnType<typeof getEvents>>["events"][number];
 }) {
 	const eventUrl = getEventUrl(event);
-	const imageUrl = event.eventImageUrl
-		? sanitizeImageUrl(event.eventImageUrl)
-		: null;
 
 	return (
 		<Link
@@ -599,19 +718,12 @@ function EventCompactCard({
 			className="group overflow-hidden border bg-card transition-colors hover:bg-muted/20"
 		>
 			<div className="relative aspect-[16/9] bg-muted">
-				{imageUrl ? (
-					<Image
-						src={imageUrl}
-						alt={event.name}
-						fill
-						className="object-cover transition-transform group-hover:scale-105"
-						sizes="(max-width: 768px) 100vw, 50vw"
-					/>
-				) : (
-					<div className="flex h-full items-center justify-center text-muted-foreground">
-						<Zap className="size-6" />
-					</div>
-				)}
+				<EventCover
+					event={event}
+					className="h-full w-full"
+					imageClassName="transition-transform group-hover:scale-105"
+					sizes="(max-width: 768px) 100vw, 50vw"
+				/>
 			</div>
 			<div className="space-y-2 border-t p-3">
 				<Badge variant="outline" className="h-5 rounded-none text-[10px]">

--- a/app/(landing)/roadmap/page.tsx
+++ b/app/(landing)/roadmap/page.tsx
@@ -19,7 +19,7 @@ import { getCountryFlag, getCountryName } from "@/lib/event-utils";
 export const metadata: Metadata = {
 	title: "Roadmap",
 	description:
-		"Conoce nuestras prioridades y visión para mapear el ecosistema tech de LATAM, empezando por Perú.",
+		"Conoce nuestras prioridades y visión para mapear el ecosistema tech de LATAM.",
 };
 
 const phases = [
@@ -147,13 +147,13 @@ export default async function RoadmapPage() {
 								<Rocket className="h-3 w-3 mr-1" />
 								Roadmap
 							</Badge>
-							<h1 className="text-3xl md:text-4xl font-bold tracking-tight">
+							<h1 className="text-3xl md:text-4xl font-bold">
 								Construyendo el mapa del ecosistema tech de LATAM
 							</h1>
 							<p className="text-muted-foreground mt-4 text-lg">
 								Nuestra misión es dar visibilidad a todas las comunidades y
-								eventos tech de Latinoamérica. Empezamos por Perú, pero la
-								visión es regional.
+								eventos tech de Latinoamérica, país por país, desde una base de
+								datos abierta y accionable.
 							</p>
 						</div>
 					</div>

--- a/app/(seo)/feed.xml/route.ts
+++ b/app/(seo)/feed.xml/route.ts
@@ -7,8 +7,8 @@ const SITE_URL = "https://hack0.dev";
 
 export async function GET() {
 	const feed = new Feed({
-		title: "hack0.dev - Eventos Tech en Perú",
-		description: "Hackathons, conferencias, workshops y eventos tech en Perú",
+		title: "hack0.dev - Eventos Tech en LATAM",
+		description: "Hackathons, conferencias, workshops y eventos tech en LATAM",
 		id: SITE_URL,
 		link: SITE_URL,
 		language: "es",
@@ -57,7 +57,7 @@ export async function GET() {
 			? event.description.length > 500
 				? `${event.description.slice(0, 497)}...`
 				: event.description
-			: `${event.name} - Evento tech en Perú`;
+			: `${event.name} - Evento tech en LATAM`;
 
 		feed.addItem({
 			title: event.name,

--- a/components/events/event-cover.tsx
+++ b/components/events/event-cover.tsx
@@ -1,0 +1,121 @@
+import Image from "next/image";
+import {
+	getCountryFlag,
+	getCountryName,
+	getEventTypeLabel,
+} from "@/lib/event-utils";
+import { cn, sanitizeImageUrl } from "@/lib/utils";
+
+type EventCoverEvent = {
+	name: string;
+	eventType: string | null;
+	country: string | null;
+	eventImageUrl: string | null;
+	organization?: {
+		slug?: string | null;
+		name?: string | null;
+		displayName?: string | null;
+		logoUrl?: string | null;
+	} | null;
+};
+
+type EventCoverProps = {
+	event: EventCoverEvent;
+	className?: string;
+	imageClassName?: string;
+	sizes: string;
+	priority?: boolean;
+	variant?: "poster" | "thumb";
+};
+
+function getShortTitle(title: string) {
+	return title.split(/\s+/).filter(Boolean).slice(0, 5).join(" ");
+}
+
+export function EventCover({
+	event,
+	className,
+	imageClassName,
+	sizes,
+	priority = false,
+	variant = "poster",
+}: EventCoverProps) {
+	const imageUrl = event.eventImageUrl
+		? sanitizeImageUrl(event.eventImageUrl)
+		: undefined;
+	const logoUrl = event.organization?.logoUrl
+		? sanitizeImageUrl(event.organization.logoUrl)
+		: undefined;
+	const country = event.country ? getCountryName(event.country) : "LATAM";
+	const flag = getCountryFlag(event.country);
+	const label = getEventTypeLabel(event.eventType);
+
+	return (
+		<div className={cn("relative overflow-hidden bg-muted", className)}>
+			{imageUrl ? (
+				<Image
+					src={imageUrl}
+					alt={event.name}
+					fill
+					className={cn("object-cover", imageClassName)}
+					sizes={sizes}
+					priority={priority}
+				/>
+			) : (
+				<div className="relative h-full w-full bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.22),transparent_32%),linear-gradient(135deg,hsl(var(--muted)),hsl(var(--background)))]">
+					<div className="absolute inset-0 opacity-[0.08] [background-image:linear-gradient(90deg,currentColor_1px,transparent_1px),linear-gradient(currentColor_1px,transparent_1px)] [background-size:18px_18px]" />
+					{variant === "thumb" ? (
+						<div className="relative flex h-full w-full items-center justify-center">
+							{logoUrl ? (
+								<Image
+									src={logoUrl}
+									alt={
+										event.organization?.displayName ||
+										event.organization?.name ||
+										event.name
+									}
+									fill
+									className="object-cover"
+									sizes={sizes}
+								/>
+							) : (
+								<span className="text-xs font-semibold text-foreground">
+									{flag || event.name.charAt(0).toUpperCase()}
+								</span>
+							)}
+						</div>
+					) : (
+						<div className="relative flex h-full w-full flex-col justify-between p-3">
+							<div className="flex items-center justify-between gap-2 text-[10px] font-medium uppercase text-muted-foreground">
+								<span>{label}</span>
+								<span className="normal-case">
+									{flag} {country}
+								</span>
+							</div>
+							<div className="space-y-2">
+								{logoUrl && (
+									<div className="relative size-8 overflow-hidden border bg-background/80">
+										<Image
+											src={logoUrl}
+											alt={
+												event.organization?.displayName ||
+												event.organization?.name ||
+												event.name
+											}
+											fill
+											className="object-cover"
+											sizes="32px"
+										/>
+									</div>
+								)}
+								<div className="max-w-[14rem] text-sm font-semibold leading-tight text-foreground">
+									{getShortTitle(event.name)}
+								</div>
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/components/events/index.ts
+++ b/components/events/index.ts
@@ -1,4 +1,5 @@
 export * from "./detail";
 export * from "./edit";
+export * from "./event-cover";
 export * from "./toolbar";
 export * from "./views";

--- a/components/events/views/event-row-with-children.tsx
+++ b/components/events/views/event-row-with-children.tsx
@@ -6,9 +6,9 @@ import {
 	ChevronRight,
 	Sparkles,
 } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { EventCover } from "@/components/events/event-cover";
 import { CalendarIcon } from "@/components/icons/calendar";
 import { PinIcon } from "@/components/icons/pin";
 import { TrophyIcon } from "@/components/icons/trophy";
@@ -115,11 +115,10 @@ export function EventRowWithChildren({
 					{/* Banner background */}
 					{event.eventImageUrl && (
 						<div className="absolute inset-0 overflow-hidden pointer-events-none">
-							<Image
-								src={event.eventImageUrl}
-								alt=""
-								fill
-								className="object-cover object-center opacity-20 group-hover:opacity-30 transition-opacity duration-300 blur-sm"
+							<EventCover
+								event={event}
+								className="h-full w-full"
+								imageClassName="object-center opacity-20 group-hover:opacity-30 transition-opacity duration-300 blur-sm"
 								sizes="100vw"
 							/>
 							<div className="absolute inset-0 bg-gradient-to-r from-background/90 via-background/70 to-background/50" />
@@ -157,19 +156,12 @@ export function EventRowWithChildren({
 								</button>
 							)}
 							<div className="relative h-9 w-9 shrink-0 overflow-hidden bg-muted border border-border/50">
-								{event.eventImageUrl ? (
-									<Image
-										src={event.eventImageUrl}
-										alt={event.name}
-										fill
-										className="object-cover"
-										sizes="36px"
-									/>
-								) : (
-									<div className="flex h-full w-full items-center justify-center text-xs font-medium text-muted-foreground">
-										{event.name.charAt(0).toUpperCase()}
-									</div>
-								)}
+								<EventCover
+									event={event}
+									className="h-full w-full"
+									sizes="36px"
+									variant="thumb"
+								/>
 							</div>
 							<div className="flex-1 min-w-0">
 								<h3 className="font-medium text-xs leading-tight line-clamp-2 group-hover:underline underline-offset-2">
@@ -257,19 +249,12 @@ export function EventRowWithChildren({
 						)}
 
 						<div className="relative h-7 w-7 shrink-0 overflow-hidden bg-muted border border-border/50">
-							{event.eventImageUrl ? (
-								<Image
-									src={event.eventImageUrl}
-									alt={event.name}
-									fill
-									className="object-cover"
-									sizes="28px"
-								/>
-							) : (
-								<div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-muted-foreground">
-									{event.name.charAt(0).toUpperCase()}
-								</div>
-							)}
+							<EventCover
+								event={event}
+								className="h-full w-full"
+								sizes="28px"
+								variant="thumb"
+							/>
 						</div>
 						<div className="min-w-0 flex-1">
 							<div className="flex items-center gap-2">
@@ -421,19 +406,12 @@ function ChildEventRow({
 			)}
 
 			<div className="relative h-5 w-5 shrink-0 overflow-hidden bg-muted border border-border/50">
-				{event.eventImageUrl ? (
-					<Image
-						src={event.eventImageUrl}
-						alt={event.name}
-						fill
-						className="object-cover"
-						sizes="20px"
-					/>
-				) : (
-					<div className="flex h-full w-full items-center justify-center text-[8px] font-medium text-muted-foreground">
-						{event.name.charAt(0).toUpperCase()}
-					</div>
-				)}
+				<EventCover
+					event={event}
+					className="h-full w-full"
+					sizes="20px"
+					variant="thumb"
+				/>
 			</div>
 
 			<div className="min-w-0 flex-1">

--- a/components/events/views/events-cards.tsx
+++ b/components/events/views/events-cards.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Calendar, MapPin, Trophy } from "lucide-react";
+import { MapPin, Trophy } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { EventCover } from "@/components/events/event-cover";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type {
@@ -19,7 +20,6 @@ import {
 	getEventUrl,
 	getFormatLabel,
 } from "@/lib/event-utils";
-import { sanitizeImageUrl } from "@/lib/utils";
 import { LoadMoreButton } from "./load-more-button";
 
 type EventWithOptionalRole = EventWithOrg & {
@@ -77,28 +77,16 @@ function EventCard({
 				className={`group gap-0 h-full overflow-hidden p-0 transition-all hover:shadow-md hover:border-foreground/20 ${isEnded ? "opacity-60" : ""}`}
 			>
 				<div className="relative aspect-square w-full overflow-hidden">
-					{event.eventImageUrl ? (
-						<Image
-							src={sanitizeImageUrl(event.eventImageUrl) ?? ""}
-							alt={event.name}
-							fill
-							className={`object-cover transition-transform group-hover:scale-105 ${isEnded ? "grayscale" : ""}`}
-							sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
-						/>
-					) : (
-						<div
-							className={`flex h-full w-full flex-col items-center justify-center gap-2 bg-gradient-to-br from-muted/80 to-muted ${isEnded ? "grayscale" : ""}`}
-						>
-							<Calendar className="h-8 w-8 text-muted-foreground/40" />
-							<span className="text-xs text-muted-foreground/60 px-4 text-center line-clamp-1">
-								{event.name}
-							</span>
-						</div>
-					)}
+					<EventCover
+						event={event}
+						className="h-full w-full"
+						imageClassName={`transition-transform group-hover:scale-105 ${isEnded ? "grayscale" : ""}`}
+						sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
+					/>
 					{isEnded && (
 						<div className="absolute inset-0 flex items-center justify-center">
 							<div className="absolute w-[150%] rotate-[-35deg] bg-muted/95 py-1 text-center shadow-sm">
-								<span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+								<span className="text-[10px] font-medium text-muted-foreground uppercase">
 									Te lo perdiste
 								</span>
 							</div>

--- a/components/events/views/events-preview-view.tsx
+++ b/components/events/views/events-preview-view.tsx
@@ -14,11 +14,11 @@ import {
 	Users,
 	Zap,
 } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { EventCover } from "@/components/events/event-cover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -101,19 +101,12 @@ function EventListItem({
 		>
 			<div className="flex gap-3">
 				<div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg bg-muted">
-					{event.eventImageUrl ? (
-						<Image
-							src={event.eventImageUrl}
-							alt={event.name}
-							fill
-							className="object-cover"
-							sizes="48px"
-						/>
-					) : (
-						<div className="flex h-full w-full items-center justify-center text-lg font-bold text-muted-foreground">
-							{event.name.charAt(0)}
-						</div>
-					)}
+					<EventCover
+						event={event}
+						className="h-full w-full"
+						sizes="48px"
+						variant="thumb"
+					/>
 				</div>
 
 				<div className="flex-1 min-w-0">
@@ -196,22 +189,12 @@ function EventDetailPanel({ event }: { event: EventWithOrg }) {
 		>
 			{/* Header with image */}
 			<div className="relative h-48 shrink-0 overflow-hidden bg-muted">
-				{event.eventImageUrl ? (
-					<Image
-						src={event.eventImageUrl}
-						alt={event.name}
-						fill
-						className="object-cover"
-						sizes="(max-width: 768px) 100vw, 50vw"
-						priority
-					/>
-				) : (
-					<div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5">
-						<span className="text-6xl font-bold text-primary/30">
-							{event.name.charAt(0)}
-						</span>
-					</div>
-				)}
+				<EventCover
+					event={event}
+					className="h-full w-full"
+					sizes="(max-width: 768px) 100vw, 50vw"
+					priority
+				/>
 				<div className="absolute inset-0 bg-gradient-to-t from-background via-background/20 to-transparent" />
 
 				{/* Status badge */}
@@ -353,7 +336,7 @@ function EventDetailPanel({ event }: { event: EventWithOrg }) {
 					{/* Description */}
 					{event.description && (
 						<div className="space-y-2">
-							<h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							<h3 className="text-xs font-medium uppercase text-muted-foreground">
 								Sobre el evento
 							</h3>
 							<div className="prose prose-sm prose-neutral dark:prose-invert max-w-none">

--- a/components/events/views/load-more-button.tsx
+++ b/components/events/views/load-more-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Calendar, Loader2, MapPin, Trophy } from "lucide-react";
-import Image from "next/image";
+import { Loader2, MapPin, Trophy } from "lucide-react";
 import Link from "next/link";
 import { useState, useTransition } from "react";
+import { EventCover } from "@/components/events/event-cover";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -62,28 +62,16 @@ function EventCard({ event }: { event: EventWithOrg }) {
 				className={`group h-full overflow-hidden p-0 transition-all hover:shadow-md hover:border-foreground/20 ${isEnded ? "opacity-60" : ""}`}
 			>
 				<div className="relative aspect-square w-full overflow-hidden">
-					{event.eventImageUrl ? (
-						<Image
-							src={event.eventImageUrl}
-							alt={event.name}
-							fill
-							className={`object-cover transition-transform group-hover:scale-105 ${isEnded ? "grayscale" : ""}`}
-							sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
-						/>
-					) : (
-						<div
-							className={`flex h-full w-full flex-col items-center justify-center gap-2 bg-gradient-to-br from-muted/80 to-muted ${isEnded ? "grayscale" : ""}`}
-						>
-							<Calendar className="h-8 w-8 text-muted-foreground/40" />
-							<span className="text-xs text-muted-foreground/60 px-4 text-center line-clamp-1">
-								{event.name}
-							</span>
-						</div>
-					)}
+					<EventCover
+						event={event}
+						className="h-full w-full"
+						imageClassName={`transition-transform group-hover:scale-105 ${isEnded ? "grayscale" : ""}`}
+						sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
+					/>
 					{isEnded && (
 						<div className="absolute inset-0 flex items-center justify-center">
 							<div className="absolute w-[150%] rotate-[-35deg] bg-muted/95 py-1 text-center shadow-sm">
-								<span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+								<span className="text-[10px] font-medium text-muted-foreground uppercase">
 									Te lo perdiste
 								</span>
 							</div>

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -89,6 +89,10 @@ export interface EventsResult {
 	hasMore: boolean;
 }
 
+const DEFAULT_EVENT_COUNTRY_CODES = LATAM_COUNTRY_CODES.filter(
+	(code) => code !== "GLOBAL",
+);
+
 export async function getEvents(
 	filters: EventFilters = {},
 ): Promise<EventsResult> {
@@ -245,6 +249,8 @@ export async function getEvents(
 	// Country filter
 	if (countries.length > 0) {
 		conditions.push(inArray(events.country, countries));
+	} else {
+		conditions.push(inArray(events.country, DEFAULT_EVENT_COUNTRY_CODES));
 	}
 
 	// Department filter

--- a/lib/builders-directory.ts
+++ b/lib/builders-directory.ts
@@ -1,8 +1,11 @@
-import { and, desc, eq, ilike, type SQL, sql } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, type SQL, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { eventHosts, events, organizations } from "@/lib/db/schema";
+import { LATAM_COUNTRY_CODES } from "@/lib/db/schema/constants";
 
-const PERU = "PE";
+const LATAM_EVENT_COUNTRIES = LATAM_COUNTRY_CODES.filter(
+	(code) => code !== "GLOBAL",
+);
 
 export interface BuilderDirectoryEntry {
 	hostKey: string;
@@ -37,7 +40,7 @@ function getHostKeySql() {
 function getBuilderConditions(search?: string): SQL[] {
 	const conditions: SQL[] = [
 		eq(events.isApproved, true),
-		eq(events.country, PERU),
+		inArray(events.country, LATAM_EVENT_COUNTRIES),
 		sql`trim(${eventHosts.name}) <> ''`,
 	];
 

--- a/lib/email/templates/cohost-invite.tsx
+++ b/lib/email/templates/cohost-invite.tsx
@@ -81,7 +81,7 @@ export function CohostInviteEmail({
 					<Hr style={hr} />
 
 					<Text style={footer}>
-						hack0.dev - Centralizando eventos tech para Perú
+						hack0.dev - Centralizando eventos tech para LATAM
 					</Text>
 				</Container>
 			</Body>

--- a/lib/email/templates/community-invite.tsx
+++ b/lib/email/templates/community-invite.tsx
@@ -103,7 +103,7 @@ export function CommunityInviteEmail({
 					<Hr style={hr} />
 
 					<Text style={footer}>
-						hack0.dev - Centralizando eventos tech para Perú
+						hack0.dev - Centralizando eventos tech para LATAM
 					</Text>
 				</Container>
 			</Body>

--- a/lib/email/templates/welcome.tsx
+++ b/lib/email/templates/welcome.tsx
@@ -26,7 +26,7 @@ export function WelcomeEmail({ confirmUrl }: WelcomeEmailProps) {
 
 					<Text style={paragraph}>
 						Estás a un paso de recibir notificaciones sobre nuevos hackathons y
-						eventos tech en Perú.
+						eventos tech en LATAM.
 					</Text>
 
 					<Text style={paragraph}>
@@ -44,7 +44,7 @@ export function WelcomeEmail({ confirmUrl }: WelcomeEmailProps) {
 					<Hr style={hr} />
 
 					<Text style={footer}>
-						hack0.dev - Centralizando eventos tech para Perú
+						hack0.dev - Centralizando eventos tech para LATAM
 					</Text>
 				</Container>
 			</Body>

--- a/lib/index-data-health.ts
+++ b/lib/index-data-health.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, isNull, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { getBuilderDirectorySummary } from "@/lib/builders-directory";
 import { db } from "@/lib/db";
 import {
@@ -14,11 +14,14 @@ import {
 } from "@/lib/db/schema";
 import {
 	EVENT_TYPE_LABELS,
+	LATAM_COUNTRY_CODES,
 	ORGANIZER_TYPE_LABELS,
 } from "@/lib/db/schema/constants";
 import { getOpportunityDirectorySummary } from "@/lib/opportunities-directory";
 
-const PERU = "PE";
+const LATAM_INDEX_COUNTRIES = LATAM_COUNTRY_CODES.filter(
+	(code) => code !== "GLOBAL",
+);
 const HACKATHON_TYPES = [
 	"hackathon",
 	"competition",
@@ -105,11 +108,11 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 	const publicOrgWhere = and(
 		eq(organizations.isPublic, true),
 		eq(organizations.isPersonalOrg, false),
-		eq(organizations.country, PERU),
+		inArray(organizations.country, LATAM_INDEX_COUNTRIES),
 	);
-	const approvedPeruEventsWhere = and(
+	const approvedLatamEventsWhere = and(
 		eq(events.isApproved, true),
-		eq(events.country, PERU),
+		inArray(events.country, LATAM_INDEX_COUNTRIES),
 		isNull(events.parentEventId),
 	);
 
@@ -139,7 +142,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 				latestSourceScrapedAt: sql<Date | null>`max(${events.sourceScrapedAt})`,
 			})
 			.from(events)
-			.where(approvedPeruEventsWhere),
+			.where(approvedLatamEventsWhere),
 		db
 			.select({
 				totalOrganizations: count(organizations.id),
@@ -170,7 +173,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			})
 			.from(eventSponsors)
 			.innerJoin(events, eq(eventSponsors.eventId, events.id))
-			.where(approvedPeruEventsWhere),
+			.where(approvedLatamEventsWhere),
 		db
 			.select({
 				relationships: count(organizationRelationships.id),
@@ -179,7 +182,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 		db
 			.select({
 				claimedProfiles: count(users.id),
-				publicPeruProfiles: sql<number>`count(*) filter (where ${users.isPublic} = true and ${users.country} = ${PERU})::int`,
+				publicLatamProfiles: sql<number>`count(*) filter (where ${users.isPublic} = true and ${inArray(users.country, LATAM_INDEX_COUNTRIES)})::int`,
 			})
 			.from(users),
 		db
@@ -197,7 +200,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 				count: count(events.id),
 			})
 			.from(events)
-			.where(approvedPeruEventsWhere)
+			.where(approvedLatamEventsWhere)
 			.groupBy(events.scrapeSource)
 			.orderBy(desc(count(events.id)))
 			.limit(8),
@@ -207,7 +210,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 				count: count(events.id),
 			})
 			.from(events)
-			.where(approvedPeruEventsWhere)
+			.where(approvedLatamEventsWhere)
 			.groupBy(events.eventType)
 			.orderBy(desc(count(events.id)))
 			.limit(8),
@@ -227,7 +230,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 				count: count(events.id),
 			})
 			.from(events)
-			.where(approvedPeruEventsWhere)
+			.where(approvedLatamEventsWhere)
 			.groupBy(events.city)
 			.orderBy(desc(count(events.id)))
 			.limit(8),
@@ -239,7 +242,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			})
 			.from(events)
 			.leftJoin(eventHosts, eq(eventHosts.eventId, events.id))
-			.where(approvedPeruEventsWhere),
+			.where(approvedLatamEventsWhere),
 	]);
 
 	const totalEvents = toNumber(eventCounts?.eventsCount);
@@ -255,7 +258,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			label: "Eventos",
 			count: totalEvents,
 			status: statusFor(totalEvents),
-			href: "/events?country=PE",
+			href: "/events",
 			source: "events",
 			evidence: `${toNumber(eventCounts?.upcomingEvents)} upcoming, ${toNumber(eventCounts?.cities)} ciudades`,
 			nextAction:
@@ -266,7 +269,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			label: "Comunidades",
 			count: totalOrganizations,
 			status: statusFor(totalOrganizations),
-			href: "/c/discover?countries=PE",
+			href: "/c/discover",
 			source: "organizations",
 			evidence: `${toNumber(organizationCounts?.verifiedOrganizations)} verificadas`,
 			nextAction:
@@ -277,7 +280,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			label: "Hackathons",
 			count: hackathons,
 			status: statusFor(hackathons),
-			href: "/events?country=PE&eventType=hackathon,competition,olympiad,robotics",
+			href: "/events?eventType=hackathon,competition,olympiad,robotics",
 			source: "events.event_type",
 			evidence: HACKATHON_TYPES.join(", "),
 			nextAction:
@@ -288,7 +291,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 			label: "Universidades y labs",
 			count: labs,
 			status: statusFor(labs),
-			href: "/c/discover?countries=PE&types=university,student_org",
+			href: "/c/discover?types=university,student_org",
 			source: "organizations.type",
 			evidence: UNIVERSITY_TYPES.join(", "),
 			nextAction:
@@ -321,7 +324,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 	const sourceBreakdown = sourceRows.map((row) => ({
 		label: row.source || "manual",
 		count: toNumber(row.count),
-		helper: "eventos aprobados PE",
+		helper: "eventos aprobados LATAM",
 	}));
 
 	const eventTypeBreakdown = eventTypeRows.map((row) => ({
@@ -341,7 +344,7 @@ export async function getIndexDataHealth(): Promise<IndexDataHealth> {
 	const cityBreakdown = cityRows.map((row) => ({
 		label: row.city || "Sin ciudad",
 		count: toNumber(row.count),
-		helper: "eventos aprobados PE",
+		helper: "eventos aprobados LATAM",
 	}));
 
 	const qualitySignals: QualitySignal[] = [

--- a/lib/opportunities-directory.ts
+++ b/lib/opportunities-directory.ts
@@ -1,7 +1,10 @@
 import { asc } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organizations } from "@/lib/db/schema";
-import { ORGANIZER_TYPE_LABELS } from "@/lib/db/schema/constants";
+import {
+	LATAM_COUNTRY_CODES,
+	ORGANIZER_TYPE_LABELS,
+} from "@/lib/db/schema/constants";
 
 export type OpportunityCategory =
 	| "accelerator"
@@ -64,6 +67,10 @@ const OPPORTUNITY_TERMS = [
 	"red angel",
 	"venture",
 ];
+const LATAM_ORG_COUNTRIES = LATAM_COUNTRY_CODES.filter(
+	(code) => code !== "GLOBAL",
+);
+const LATAM_ORG_COUNTRY_SET = new Set<string>(LATAM_ORG_COUNTRIES);
 
 function normalize(value: string | null | undefined) {
 	return (value || "")
@@ -107,7 +114,7 @@ function getOpportunityCategory(
 function isOpportunityOrg(org: RawOpportunityOrganization) {
 	const text = searchableText(org);
 	return (
-		org.country === "PE" &&
+		Boolean(org.country && LATAM_ORG_COUNTRY_SET.has(org.country)) &&
 		(org.type === "investor" ||
 			OPPORTUNITY_TERMS.some((term) => text.includes(term)))
 	);


### PR DESCRIPTION
## Summary
- Reframes the landing, directory, roadmap, RSS, OG fallback, emails, and docs from Peru-only to LATAM-first.
- Adds a shared EventCover so event lists/cards use real images when available and branded fallbacks when future imports lack a cover.
- Makes event APIs and directory summaries honor LATAM defaults instead of PE-only defaults.
- Backfilled current Neon events with missing covers, verified all 186 LATAM events now have eventImageUrl locally via the API.

## Verification
- bun --bun tsc --noEmit --pretty false
- bun run build
- git diff --check
- Local API smoke: /api/events?timeFilter=all pages 1 and 2 returned zero events without images.
- agent-browser screenshots: landing desktop/mobile and /events?view=preview, including Explora Tech Lima, Build with AI, and Kubernetes covers.