### PR TITLE
feat(ingestion): add deduplication foundation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,12 +48,13 @@ Diagnosed 2026-07-23 (see MAK-186 comment for full detail):
 - **Root cause:** the Trigger.dev pipeline (hourly Luma cron `trigger/luma-calendar-sync.ts` + daily/weekly scrapers) **does not run in prod**. There is no `trigger:deploy` script and no CI workflow to deploy it; Trigger.dev v3 crons only fire in the cloud after a deploy. Plus credits were exhausted (MAK-186).
 - **Secondary cause:** scraped events enter as `pending` (`isApproved:false`, `lib/scraper/normalizer.ts`) and stay invisible until curated in `/god/events`. (Luma sync auto-approves.)
 
-**Fix checklist** (not yet executed):
-1. Restore Trigger.dev credits + add `trigger:deploy` to `package.json` and a CI workflow running `trigger.dev deploy` on push to main.
-2. Verify prod env parity: `DATABASE_URL` (Trigger prod == Vercel Neon), `LUMA_API_KEY`/`LUMA_API_KEYS`, `TRIGGER_PROJECT_ID`, `FIRECRAWL_API_KEY`.
-3. Register/verify the Luma webhook (`app/(app)/api/webhooks/luma/route.ts`) for on-demand freshness.
-4. Operate the curation queue (`/god/events`) or auto-approve trusted sources.
-5. Stopgap: run `bun run sync:luma` against the prod DB.
+**Fix checklist** (incremental rollout):
+1. Complete the shared validation, write-safety, deduplication, and consistency foundations.
+2. Add secure two-way Hack0-Luma synchronization so every published Hack0 event is represented in the Hack0 calendar without creating duplicate registrations.
+3. Add and validate one source at a time using the gate in [`event-ingestion-rollout.md`](./event-ingestion-rollout.md).
+4. Deploy Trigger.dev versions without promotion, inspect manual runs, then activate only the approved source schedule.
+5. Verify production env parity before any promoted run: `DATABASE_URL` (Trigger prod == Vercel Neon), `LUMA_API_KEY`/`LUMA_API_KEYS`, `TRIGGER_PROJECT_ID`, `FIRECRAWL_API_KEY`.
+6. Operate the curation queue (`/god/events`) or auto-approve only explicitly trusted sources.
 
 ## 5. Design — SSOT is `brand.md` (v0.2)
 

--- a/docs/event-ingestion-rollout.md
+++ b/docs/event-ingestion-rollout.md
@@ -1,0 +1,83 @@
+# Event ingestion rollout
+
+This document defines the release gate for every event source connected to
+hack0. It complements the community-tooling phases in
+[`implementation-phases.md`](./implementation-phases.md).
+
+## Foundations
+
+Before a source can write events, the shared pipeline must provide:
+
+- runtime validation of the source-neutral event candidate;
+- consistency checks for dates and required discovery fields;
+- canonical URL comparison with tracking parameters removed;
+- exact matching by provider and external ID;
+- high-confidence matching by name, date, and compatible location;
+- a manual-review state for possible, non-exact matches;
+- collision-safe slugs that are not treated as event identity;
+- dry-run reports and explicit production write authorization.
+
+## Source release gate
+
+Each source ships in its own branch and pull request. The gate is:
+
+1. Implement the adapter without enabling a production schedule.
+2. Run it in dry-run mode.
+3. Review totals for rejected, inconsistent, duplicate, ambiguous, and new
+   events.
+4. Inspect a representative sample for LATAM relevance, dates, links, images,
+   location, and organizer.
+5. Verify in-batch idempotency with duplicate fixtures and confirm that the
+   dry-run output contains no duplicate insert candidates.
+6. With explicit approval, perform a small production canary import.
+7. Re-run the canary input in dry-run mode. It must report zero new events.
+8. Confirm the imported events in hack0 and, once two-way sync is available, in
+   the Hack0 Luma calendar.
+9. Deploy a Trigger.dev version without promotion and run only the new task.
+10. Promote the version and activate only that source's schedule after review.
+11. Monitor the first scheduled run and deactivate the schedule on regression.
+
+Trigger.dev versions contain all project tasks. "Deploy one source" therefore
+means that only the approved source receives an active schedule; the other
+source tasks remain disabled or read-only. All event-writing Trigger tasks share
+one queue with concurrency `1`, so two sources cannot deduplicate and write
+against the same database snapshot simultaneously.
+
+## Deduplication outcomes
+
+The pipeline assigns one outcome to every consistent candidate:
+
+| Outcome | Meaning | Automatic write |
+|---|---|---|
+| `insert` | No match was found. | Allowed after the source gate. |
+| `skip` | Exact or high-confidence duplicate. | No. |
+| `review` | Possible duplicate or incomplete consistency data. | No. |
+| `reject` | Invalid or contradictory data. | No. |
+
+An exact provider ID can be skipped automatically. A canonical event URL can
+also be skipped when the dates are compatible; reused URLs with conflicting
+dates go to review. Similar names alone are never enough. A high-confidence
+fuzzy match also requires a close date and compatible location.
+
+## Planned source order
+
+1. Devpost.
+2. Calendar router API.
+3. Luma calendars connected by opted-in hack0 users.
+4. Peruanos.dev.
+5. LATAM-filtered Luma discovery.
+6. Exa and Firecrawl discovery queries.
+
+Two-way Hack0-Luma synchronization is a shared foundation that must be complete
+before unattended source writes are enabled.
+
+## Read-only duplicate audit
+
+Run the following command to inspect the current database without modifying it:
+
+```bash
+bun run audit:duplicates
+```
+
+The command only selects the event identity fields required by the matcher. It
+does not call external source APIs and does not insert, update, or delete rows.

--- a/docs/implementation-phases.md
+++ b/docs/implementation-phases.md
@@ -2,6 +2,10 @@
 
 > Arquitectura/decisión: [`consolidation-plan.md`](./consolidation-plan.md). Este doc = la secuencia de ejecución (fases con gate + rollback), **todo en el repo hack0, por branches con PR**. **Estado:** aprobado; implementación de features aún no iniciada. **Fecha:** 2026-07-27.
 
+> La estabilización e incorporación gradual de fuentes de eventos se ejecuta
+> primero según [`event-ingestion-rollout.md`](./event-ingestion-rollout.md).
+> Ninguna fuente se agenda en producción hasta pasar su gate individual.
+
 ## Principios
 - **Stack de hack0 sin cambios** (Next.js/Neon/Clerk/Vercel/Trigger.dev). Reusar lo existente antes de crear.
 - **Branches + PR por fase**, cada una con su gate de verificación; merge solo con gate verde.

--- a/docs/setup-and-data-sources.md
+++ b/docs/setup-and-data-sources.md
@@ -171,11 +171,17 @@ Expected outcomes in write mode:
 
 - Luma source: approved events from the Hack0 calendar.
 - Devpost source: pending events for manual curation.
-- Deduplication prevents same URL/slug/name-date duplicates from being inserted.
+- Deduplication checks provider IDs, canonical URLs, and name/date/location.
+- Possible matches are held for review instead of being inserted.
+- Slug collisions receive a deterministic suffix; a shared slug alone is not
+  considered proof that two events are the same.
 
 Trigger scraper tasks also default to dry-run. Their orchestrators remain
 read-only until the production deployment phase explicitly enables validated
 sources.
+
+The complete per-source validation and release gate is documented in
+[`event-ingestion-rollout.md`](./event-ingestion-rollout.md).
 
 ## Validation
 

--- a/lib/ingestion/__tests__/consistency.test.ts
+++ b/lib/ingestion/__tests__/consistency.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { NewEvent } from "@/lib/db/schema/events";
+import { checkEventConsistency } from "@/lib/ingestion/consistency";
+
+function event(overrides: Partial<NewEvent> = {}): NewEvent {
+	return {
+		name: "LATAM Builders Day",
+		slug: "latam-builders-day",
+		websiteUrl: "https://example.com/latam-builders-day",
+		organizationId: "00000000-0000-0000-0000-000000000001",
+		startDate: new Date("2026-08-10T14:00:00Z"),
+		endDate: new Date("2026-08-10T18:00:00Z"),
+		format: "virtual",
+		...overrides,
+	};
+}
+
+describe("checkEventConsistency", () => {
+	test("accepts a complete event", () => {
+		const result = checkEventConsistency(event());
+
+		assert.equal(result.status, "valid");
+		assert.equal(result.issues.length, 0);
+	});
+
+	test("holds undated events for review", () => {
+		const result = checkEventConsistency(event({ startDate: null }));
+
+		assert.equal(result.status, "review");
+		assert.equal(result.issues[0].code, "missing_start_date");
+	});
+
+	test("rejects an end date before the start date", () => {
+		const result = checkEventConsistency(
+			event({ endDate: new Date("2026-08-09T18:00:00Z") }),
+		);
+
+		assert.equal(result.status, "reject");
+		assert.equal(result.issues[0].code, "end_before_start");
+	});
+
+	test("warns about an in-person event without a location", () => {
+		const result = checkEventConsistency(
+			event({ format: "in-person", country: null, city: null }),
+		);
+
+		assert.equal(result.status, "valid");
+		assert.equal(result.issues[0].severity, "warning");
+	});
+
+	test("holds a country contradiction for review", () => {
+		const result = checkEventConsistency(
+			event({
+				name: "[Bogotá] Full Day Hackathon",
+				country: "PE",
+				city: null,
+			}),
+		);
+
+		assert.equal(result.status, "review");
+		assert.equal(result.issues[0].code, "country_name_mismatch");
+	});
+
+	test("uses the longest city name when locations overlap", () => {
+		const result = checkEventConsistency(
+			event({
+				name: "Café Cursor Nova Lima",
+				country: "BR",
+				city: "Nova Lima",
+			}),
+		);
+
+		assert.equal(result.status, "valid");
+		assert.equal(result.issues.length, 0);
+	});
+});

--- a/lib/ingestion/__tests__/deduplicator.test.ts
+++ b/lib/ingestion/__tests__/deduplicator.test.ts
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { NewEvent } from "@/lib/db/schema/events";
+import {
+	auditEventCollection,
+	type ComparableEvent,
+	canonicalizeEventUrl,
+	deduplicateEvents,
+	eventNameSimilarity,
+} from "@/lib/scraper/deduplicator";
+
+function event(overrides: Partial<NewEvent> = {}): NewEvent {
+	return {
+		name: "LATAM AI Hackathon",
+		slug: "latam-ai-hackathon",
+		websiteUrl: "https://example.com/events/latam-ai",
+		organizationId: "00000000-0000-0000-0000-000000000001",
+		startDate: new Date("2026-08-10T14:00:00Z"),
+		format: "in-person",
+		country: "PE",
+		city: "Lima",
+		scrapeSource: "devpost",
+		scrapeSourceUrl: "https://latam-ai.devpost.com/",
+		scrapeRawData: { externalId: "latam-ai" },
+		...overrides,
+	};
+}
+
+function existing(overrides: Partial<ComparableEvent> = {}): ComparableEvent {
+	return {
+		...event(),
+		id: "event-existing",
+		...overrides,
+	};
+}
+
+describe("canonicalizeEventUrl", () => {
+	test("removes tracking data and normalizes Luma host aliases", () => {
+		assert.equal(
+			canonicalizeEventUrl(
+				"https://www.lu.ma/latam-ai/?utm_source=newsletter&b=2&a=1#top",
+			),
+			"luma.com/latam-ai?a=1&b=2",
+		);
+	});
+
+	test("keeps meaningful query parameters", () => {
+		assert.equal(
+			canonicalizeEventUrl("https://events.example.com/view?id=42&utm_x=1"),
+			"events.example.com/view?id=42",
+		);
+	});
+});
+
+describe("eventNameSimilarity", () => {
+	test("handles accents and token order", () => {
+		assert.ok(
+			eventNameSimilarity("Perú AI Hackathon 2026", "Hackathon AI Peru 2026") >=
+				0.9,
+		);
+	});
+});
+
+describe("deduplicateEvents", () => {
+	test("skips the same provider external id", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					websiteUrl: "https://another.example.com/event",
+					scrapeSourceUrl: "https://another.devpost.com",
+				}),
+			],
+			[existing()],
+		);
+
+		assert.equal(report.summary.duplicates, 1);
+		assert.equal(report.decisions[0].reason, "source_external_id");
+	});
+
+	test("skips canonical URL variants", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					scrapeRawData: null,
+					scrapeSource: "exa_discovery",
+					websiteUrl: "https://example.com/events/latam-ai/?utm_source=exa",
+				}),
+			],
+			[
+				existing({
+					scrapeRawData: null,
+					scrapeSource: "other",
+					scrapeSourceUrl: null,
+				}),
+			],
+		);
+
+		assert.equal(report.summary.duplicates, 1);
+		assert.equal(report.decisions[0].reason, "canonical_url");
+	});
+
+	test("holds reused URLs with conflicting dates for review", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					scrapeRawData: null,
+					scrapeSource: "exa_discovery",
+					startDate: new Date("2027-08-10T14:00:00Z"),
+				}),
+			],
+			[
+				existing({
+					scrapeRawData: null,
+					scrapeSource: "other",
+					scrapeSourceUrl: null,
+				}),
+			],
+		);
+
+		assert.equal(report.summary.needsReview, 1);
+		assert.equal(report.summary.duplicates, 0);
+		assert.equal(report.decisions[0].reason, "canonical_url_date_conflict");
+	});
+
+	test("uses name, date, and location together for a high-confidence match", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					name: "Hackathon AI LATAM",
+					websiteUrl: "https://different.example.com/ai",
+					scrapeSourceUrl: "https://different.example.com/source",
+					scrapeRawData: null,
+				}),
+			],
+			[
+				existing({
+					scrapeRawData: null,
+					scrapeSourceUrl: null,
+				}),
+			],
+		);
+
+		assert.equal(report.summary.duplicates, 1);
+		assert.equal(report.decisions[0].reason, "name_date_location");
+	});
+
+	test("does not merge similar events in different countries", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					websiteUrl: "https://mexico.example.com/ai",
+					scrapeSourceUrl: "https://mexico.example.com/source",
+					scrapeRawData: null,
+					country: "MX",
+					city: "Ciudad de Mexico",
+				}),
+			],
+			[
+				existing({
+					scrapeRawData: null,
+					scrapeSourceUrl: null,
+				}),
+			],
+		);
+
+		assert.equal(report.summary.new, 1);
+		assert.equal(report.summary.duplicates, 0);
+	});
+
+	test("holds an uncertain name and date match for review", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					name: "LATAM AI Hackathon 2026",
+					websiteUrl: "https://different.example.com/ai",
+					scrapeSourceUrl: "https://different.example.com/source",
+					scrapeRawData: null,
+					country: null,
+					city: null,
+				}),
+			],
+			[
+				existing({
+					scrapeRawData: null,
+					scrapeSourceUrl: null,
+					country: null,
+					city: null,
+				}),
+			],
+		);
+
+		assert.equal(report.summary.needsReview, 1);
+		assert.equal(report.summary.new, 0);
+	});
+
+	test("treats a repeated batch as idempotent", () => {
+		const first = deduplicateEvents(
+			[
+				event(),
+				event({
+					name: "Lima Web3 Day",
+					slug: "lima-web3-day",
+					websiteUrl: "https://example.com/events/web3",
+					scrapeSourceUrl: "https://lima-web3.devpost.com",
+					scrapeRawData: { externalId: "lima-web3" },
+				}),
+			],
+			[],
+		);
+		const second = deduplicateEvents(
+			first.newEvents,
+			first.newEvents.map((item, index) => ({
+				...item,
+				id: `persisted:${index}`,
+			})),
+		);
+
+		assert.equal(first.summary.new, 2);
+		assert.equal(second.summary.new, 0);
+		assert.equal(second.summary.duplicates, 2);
+	});
+
+	test("does not use a shared slug as proof of a duplicate", () => {
+		const report = deduplicateEvents(
+			[
+				event({
+					websiteUrl: "https://example.com/latam-ai-2027",
+					scrapeSourceUrl: "https://latam-ai-2027.devpost.com",
+					scrapeRawData: { externalId: "latam-ai-2027" },
+					startDate: new Date("2027-08-10T14:00:00Z"),
+				}),
+			],
+			[existing()],
+		);
+
+		assert.equal(report.summary.new, 1);
+		assert.notEqual(report.newEvents[0].slug, "latam-ai-hackathon");
+	});
+});
+
+describe("auditEventCollection", () => {
+	test("reports exact and possible duplicates without changing input", () => {
+		const collection: ComparableEvent[] = [
+			existing(),
+			existing({ id: "exact-copy" }),
+			existing({
+				id: "possible-copy",
+				scrapeRawData: null,
+				scrapeSourceUrl: "https://different.example.com/source",
+				websiteUrl: "https://different.example.com/event",
+				country: null,
+				city: null,
+			}),
+		];
+
+		const report = auditEventCollection(collection);
+
+		assert.equal(report.summary.total, 3);
+		assert.equal(report.summary.duplicates, 1);
+		assert.equal(report.summary.needsReview, 1);
+		assert.equal(collection.length, 3);
+	});
+});

--- a/lib/ingestion/consistency.ts
+++ b/lib/ingestion/consistency.ts
@@ -1,0 +1,123 @@
+import { LATAM_CITIES, LATAM_COUNTRY_NAMES } from "@/lib/scraper/latam-filter";
+
+export type ConsistencySeverity = "warning" | "review" | "reject";
+export type ConsistencyIssueCode =
+	| "missing_start_date"
+	| "end_before_start"
+	| "registration_after_end"
+	| "missing_in_person_location"
+	| "country_name_mismatch";
+
+export interface ConsistencyEvent {
+	name: string;
+	startDate?: Date | null;
+	endDate?: Date | null;
+	registrationDeadline?: Date | null;
+	format?: string | null;
+	country?: string | null;
+	city?: string | null;
+}
+
+export interface ConsistencyIssue {
+	code: ConsistencyIssueCode;
+	severity: ConsistencySeverity;
+	message: string;
+}
+
+export interface ConsistencyResult {
+	status: "valid" | "review" | "reject";
+	issues: ConsistencyIssue[];
+}
+
+function normalizeLocationText(value: string) {
+	return ` ${value
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()} `;
+}
+
+function inferCountryFromName(name: string) {
+	const normalizedName = normalizeLocationText(name);
+	const places = [
+		...Object.entries(LATAM_COUNTRY_NAMES),
+		...Object.entries(LATAM_CITIES),
+	].sort(([left], [right]) => right.length - left.length);
+
+	for (const [place, country] of places) {
+		if (normalizedName.includes(normalizeLocationText(place))) return country;
+	}
+	return null;
+}
+
+export function checkEventConsistency(
+	event: ConsistencyEvent,
+): ConsistencyResult {
+	const issues: ConsistencyIssue[] = [];
+
+	if (!event.startDate) {
+		issues.push({
+			code: "missing_start_date",
+			severity: "review",
+			message: "A start date is required before automatic insertion",
+		});
+	}
+
+	if (
+		event.startDate &&
+		event.endDate &&
+		event.endDate.getTime() < event.startDate.getTime()
+	) {
+		issues.push({
+			code: "end_before_start",
+			severity: "reject",
+			message: "End date occurs before start date",
+		});
+	}
+
+	if (
+		event.registrationDeadline &&
+		event.endDate &&
+		event.registrationDeadline.getTime() > event.endDate.getTime()
+	) {
+		issues.push({
+			code: "registration_after_end",
+			severity: "review",
+			message: "Registration deadline occurs after the event ends",
+		});
+	}
+
+	if (
+		(event.format === "in-person" || event.format === "hybrid") &&
+		!event.country &&
+		!event.city
+	) {
+		issues.push({
+			code: "missing_in_person_location",
+			severity: "warning",
+			message: "In-person event has no country or city",
+		});
+	}
+
+	const countryFromName = inferCountryFromName(event.name);
+	if (
+		event.country &&
+		countryFromName &&
+		event.country.toUpperCase() !== countryFromName
+	) {
+		issues.push({
+			code: "country_name_mismatch",
+			severity: "review",
+			message: `Name suggests ${countryFromName}, but country is ${event.country.toUpperCase()}`,
+		});
+	}
+
+	const status = issues.some((issue) => issue.severity === "reject")
+		? "reject"
+		: issues.some((issue) => issue.severity === "review")
+			? "review"
+			: "valid";
+
+	return { status, issues };
+}

--- a/lib/ingestion/ingest.ts
+++ b/lib/ingestion/ingest.ts
@@ -4,10 +4,30 @@ import {
 	type CandidateRejection,
 	validateEventCandidates,
 } from "@/lib/ingestion/candidate";
+import {
+	type ConsistencyIssue,
+	checkEventConsistency,
+} from "@/lib/ingestion/consistency";
 import { assertWriteAllowed, type IngestionMode } from "@/lib/ingestion/safety";
 import type { EventCandidate } from "@/lib/ingestion/types";
-import { deduplicateAgainstDB } from "@/lib/scraper/deduplicator";
+import {
+	type DeduplicationDecision,
+	type DeduplicationReason,
+	deduplicateAgainstDBWithReport,
+} from "@/lib/scraper/deduplicator";
 import { normalizeHackathon } from "@/lib/scraper/normalizer";
+
+const REPORT_LIMIT = 100;
+
+export interface IngestionDecision {
+	name: string;
+	action: "insert" | "skip" | "review" | "reject";
+	reason: DeduplicationReason | "consistency";
+	matchedEventId?: string;
+	matchedEventName?: string;
+	issues?: ConsistencyIssue[];
+	evidence?: DeduplicationDecision["evidence"];
+}
 
 export interface IngestionResult {
 	mode: IngestionMode;
@@ -16,9 +36,15 @@ export interface IngestionResult {
 	rejected: number;
 	normalized: number;
 	invalidNormalized: number;
+	consistencyRejected: number;
+	consistencyWarnings: number;
+	duplicates: number;
+	needsReview: number;
 	wouldInsert: number;
 	inserted: number;
 	rejections: CandidateRejection[];
+	decisions: IngestionDecision[];
+	reportTruncated: boolean;
 }
 
 function isValidDate(value: unknown) {
@@ -44,13 +70,45 @@ export async function ingestEventCandidates(
 		return true;
 	});
 
-	const newEvents = await deduplicateAgainstDB(validNormalized);
+	const consistency = validNormalized.map((event) => ({
+		event,
+		result: checkEventConsistency(event),
+	}));
+	const eligibleWithConsistency = consistency
+		.filter(({ result }) => result.status === "valid")
+		.map(({ event, result }) => ({ event, issues: result.issues }));
+	const eligible = eligibleWithConsistency.map(({ event }) => event);
+	const consistencyDecisions: IngestionDecision[] = consistency
+		.filter(({ result }) => result.status !== "valid")
+		.map(({ event, result }) => ({
+			name: event.name,
+			action: result.status === "reject" ? "reject" : "review",
+			reason: "consistency",
+			issues: result.issues,
+		}));
+
+	const deduplication = await deduplicateAgainstDBWithReport(eligible);
+	const decisions: IngestionDecision[] = [
+		...consistencyDecisions,
+		...deduplication.decisions.map((decision) => {
+			const issues = eligibleWithConsistency[decision.index]?.issues;
+			return {
+				name: decision.name,
+				action: decision.action,
+				reason: decision.reason,
+				matchedEventId: decision.matchedEventId,
+				matchedEventName: decision.matchedEventName,
+				issues: issues?.length ? issues : undefined,
+				evidence: decision.evidence,
+			};
+		}),
+	];
 	let inserted = 0;
 
-	if (options.mode === "write" && newEvents.length > 0) {
+	if (options.mode === "write" && deduplication.newEvents.length > 0) {
 		const rows = await db
 			.insert(events)
-			.values(newEvents)
+			.values(deduplication.newEvents)
 			.onConflictDoNothing()
 			.returning({ id: events.id });
 		inserted = rows.length;
@@ -63,8 +121,23 @@ export async function ingestEventCandidates(
 		rejected: validation.rejected.length,
 		normalized: validNormalized.length,
 		invalidNormalized: normalized.length - validNormalized.length,
-		wouldInsert: newEvents.length,
+		consistencyRejected: consistency.filter(
+			({ result }) => result.status === "reject",
+		).length,
+		consistencyWarnings: consistency.reduce(
+			(total, { result }) =>
+				total +
+				result.issues.filter((issue) => issue.severity === "warning").length,
+			0,
+		),
+		duplicates: deduplication.summary.duplicates,
+		needsReview:
+			consistency.filter(({ result }) => result.status === "review").length +
+			deduplication.summary.needsReview,
+		wouldInsert: deduplication.summary.new,
 		inserted,
 		rejections: validation.rejected,
+		decisions: decisions.slice(0, REPORT_LIMIT),
+		reportTruncated: decisions.length > REPORT_LIMIT,
 	};
 }

--- a/lib/scraper/deduplicator.ts
+++ b/lib/scraper/deduplicator.ts
@@ -1,252 +1,540 @@
-import { differenceInDays } from "date-fns";
-import { and, eq, gte, lte, sql } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { events } from "@/lib/db/schema";
 import type { NewEvent } from "@/lib/db/schema/events";
-import type { SourceType } from "@/lib/scraper/types";
 
-// ---------------------------------------------------------------------------
-// Text utils (inlined to avoid extra dependency)
-// ---------------------------------------------------------------------------
+const TRACKING_PARAMS = new Set([
+	"fbclid",
+	"gclid",
+	"mc_cid",
+	"mc_eid",
+	"ref",
+	"referrer",
+	"source",
+]);
 
-/** Normalize a string for comparison: lowercase, strip accents, remove punctuation, collapse spaces. */
-function normalizeForComparison(s: string): string {
-	return s
+const URL_HOST_ALIASES: Record<string, string> = {
+	"lu.ma": "luma.com",
+	"www.lu.ma": "luma.com",
+	"www.luma.com": "luma.com",
+};
+
+const EXACT_MATCH_REASONS = ["source_external_id", "canonical_url"] as const;
+
+export type DeduplicationAction = "insert" | "skip" | "review";
+export type DeduplicationConfidence = "exact" | "high" | "possible";
+export type DeduplicationReason =
+	| (typeof EXACT_MATCH_REASONS)[number]
+	| "canonical_url_date_conflict"
+	| "name_date_location"
+	| "ambiguous_name_date"
+	| "new_event";
+
+export interface ComparableEvent {
+	id?: string;
+	slug?: string | null;
+	name: string;
+	startDate?: Date | null;
+	format?: string | null;
+	country?: string | null;
+	city?: string | null;
+	websiteUrl?: string | null;
+	registrationUrl?: string | null;
+	devpostUrl?: string | null;
+	scrapeSource?: string | null;
+	scrapeSourceUrl?: string | null;
+	externalId?: string | null;
+	scrapeRawData?: unknown;
+}
+
+export interface DeduplicationDecision {
+	index: number;
+	eventId?: string;
+	name: string;
+	action: DeduplicationAction;
+	reason: DeduplicationReason;
+	confidence: DeduplicationConfidence;
+	matchedEventId?: string;
+	matchedEventName?: string;
+	slug?: string;
+	evidence?: {
+		startDate?: string;
+		country?: string | null;
+		city?: string | null;
+		url?: string;
+		matchedStartDate?: string;
+		matchedCountry?: string | null;
+		matchedCity?: string | null;
+		matchedUrl?: string;
+	};
+}
+
+export interface DeduplicationReport {
+	newEvents: NewEvent[];
+	decisions: DeduplicationDecision[];
+	summary: {
+		total: number;
+		new: number;
+		duplicates: number;
+		needsReview: number;
+	};
+}
+
+export interface DuplicateAuditReport {
+	decisions: DeduplicationDecision[];
+	summary: {
+		total: number;
+		unique: number;
+		duplicates: number;
+		needsReview: number;
+	};
+}
+
+interface Match {
+	action: Exclude<DeduplicationAction, "insert">;
+	reason: Exclude<DeduplicationReason, "new_event">;
+	confidence: DeduplicationConfidence;
+	existing: ComparableEvent;
+	rank: number;
+}
+
+function normalizeText(value: string): string {
+	return value
 		.toLowerCase()
 		.normalize("NFD")
-		.replace(/[\u0300-\u036f]/g, "") // strip accents
-		.replace(/[^a-z0-9\s]/g, " ") // strip punctuation
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9\s]/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();
 }
 
-// ---------------------------------------------------------------------------
-// Levenshtein distance implementation (avoids dependency issues)
-// ---------------------------------------------------------------------------
-
 function levenshteinDistance(a: string, b: string): number {
-	const matrix: number[][] = [];
-	for (let i = 0; i <= b.length; i++) matrix[i] = [i];
-	for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
+	const previous = Array.from({ length: a.length + 1 }, (_, index) => index);
 
-	for (let i = 1; i <= b.length; i++) {
-		for (let j = 1; j <= a.length; j++) {
-			if (b.charAt(i - 1) === a.charAt(j - 1)) {
-				matrix[i][j] = matrix[i - 1][j - 1];
-			} else {
-				matrix[i][j] = Math.min(
-					matrix[i - 1][j - 1] + 1,
-					matrix[i][j - 1] + 1,
-					matrix[i - 1][j] + 1,
-				);
+	for (let row = 1; row <= b.length; row++) {
+		const current = [row];
+		for (let column = 1; column <= a.length; column++) {
+			current[column] =
+				a[column - 1] === b[row - 1]
+					? previous[column - 1]
+					: Math.min(
+							previous[column - 1] + 1,
+							previous[column] + 1,
+							current[column - 1] + 1,
+						);
+		}
+		previous.splice(0, previous.length, ...current);
+	}
+
+	return previous[a.length];
+}
+
+function tokenSimilarity(a: string, b: string): number {
+	const left = new Set(a.split(" ").filter(Boolean));
+	const right = new Set(b.split(" ").filter(Boolean));
+	const union = new Set([...left, ...right]);
+	if (union.size === 0) return 1;
+
+	let intersection = 0;
+	for (const token of left) {
+		if (right.has(token)) intersection++;
+	}
+	return intersection / union.size;
+}
+
+export function eventNameSimilarity(a: string, b: string): number {
+	const left = normalizeText(a);
+	const right = normalizeText(b);
+	const maxLength = Math.max(left.length, right.length);
+	const levenshtein =
+		maxLength === 0 ? 1 : 1 - levenshteinDistance(left, right) / maxLength;
+	return Math.max(levenshtein, tokenSimilarity(left, right));
+}
+
+export function canonicalizeEventUrl(value: string | null | undefined) {
+	if (!value) return null;
+
+	try {
+		const parsed = new URL(value.trim());
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+			return null;
+
+		const rawHost = parsed.hostname.toLowerCase();
+		const hostname = URL_HOST_ALIASES[rawHost] ?? rawHost.replace(/^www\./, "");
+		const pathname = parsed.pathname
+			.replace(/\/{2,}/g, "/")
+			.replace(/\/+$/, "");
+
+		for (const key of [...parsed.searchParams.keys()]) {
+			const normalizedKey = key.toLowerCase();
+			if (
+				normalizedKey.startsWith("utm_") ||
+				TRACKING_PARAMS.has(normalizedKey)
+			) {
+				parsed.searchParams.delete(key);
 			}
 		}
+		parsed.searchParams.sort();
+
+		const query = parsed.searchParams.toString();
+		return `${hostname}${pathname || "/"}${query ? `?${query}` : ""}`;
+	} catch {
+		return null;
 	}
-	return matrix[b.length][a.length];
 }
 
-function normalizedLevenshtein(a: string, b: string): number {
-	const maxLen = Math.max(a.length, b.length);
-	if (maxLen === 0) return 0;
-	return levenshteinDistance(a, b) / maxLen;
-}
-
-/**
- * Sort the whitespace-delimited tokens of a string alphabetically.
- * "omega hack 2026 eafit" → "2026 eafit hack omega"
- * This makes the similarity metric robust to word-order variations
- * (e.g. "OmegaHack EAFIT 2026" vs "Omega Hack 2026 EAFIT").
- */
-function tokenSort(s: string): string {
-	return s.split(/\s+/).sort().join(" ");
-}
-
-/**
- * Robust name distance: min(raw Levenshtein, token-sorted Levenshtein).
- * Using the minimum means we reward the best possible alignment between
- * two strings regardless of word order, which is the common real-world
- * variant when the same event is listed on two different platforms.
- */
-function robustNameDistance(a: string, b: string): number {
-	const raw = normalizedLevenshtein(a, b);
-	const sorted = normalizedLevenshtein(tokenSort(a), tokenSort(b));
-	return Math.min(raw, sorted);
-}
-
-function normalizeUrlForDedup(url: string): string {
-	return url.toLowerCase().replace(/\/+$/, "").split("?")[0].split("#")[0];
-}
-
-export interface DeduplicationResult {
-	isNew: boolean;
-	existingId?: string;
-	action: "insert" | "update" | "skip";
-}
-
-export async function findDuplicate(
-	normalized: NewEvent,
-	sourceType: SourceType,
-	sourceUrl: string,
-): Promise<DeduplicationResult> {
-	// Pass 1: Exact slug match
-	if (normalized.slug) {
-		const slugMatch = await db
-			.select()
-			.from(events)
-			.where(eq(events.slug, normalized.slug))
-			.limit(1);
-
-		if (slugMatch.length > 0) {
-			console.info(
-				`[deduplicator] Duplicate found (slug match): ${normalized.slug}`,
-			);
-			return { isNew: false, existingId: slugMatch[0].id, action: "update" };
-		}
+function externalIdentity(event: ComparableEvent) {
+	if (!event.scrapeSource) return null;
+	if (event.externalId?.trim()) {
+		return `${event.scrapeSource.trim().toLowerCase()}:${event.externalId.trim()}`;
+	}
+	if (!event.scrapeRawData) return null;
+	if (
+		typeof event.scrapeRawData !== "object" ||
+		Array.isArray(event.scrapeRawData)
+	) {
+		return null;
 	}
 
-	// Pass 2: Same website URL (normalize both sides for consistent matching)
-	if (normalized.websiteUrl) {
-		const dedupedUrl = normalizeUrlForDedup(normalized.websiteUrl);
-		const urlMatch = await db
-			.select()
-			.from(events)
-			.where(
-				sql`lower(regexp_replace(trim(trailing '/' from coalesce(${events.websiteUrl}, '')), '[?#].*$', '')) = ${dedupedUrl}`,
-			)
-			.limit(1);
+	const externalId = (event.scrapeRawData as Record<string, unknown>)
+		.externalId;
+	if (typeof externalId !== "string" || externalId.trim().length === 0) {
+		return null;
+	}
 
-		if (urlMatch.length > 0) {
-			console.info(
-				`[deduplicator] Duplicate found (URL match): ${normalized.websiteUrl}`,
-			);
-			return { isNew: false, existingId: urlMatch[0].id, action: "update" };
-		}
+	return `${event.scrapeSource.trim().toLowerCase()}:${externalId.trim()}`;
+}
 
-		// Also check scrapeSourceUrl column
-		const sourceUrlMatch = await db
-			.select({ id: events.id })
-			.from(events)
-			.where(
-				sql`lower(regexp_replace(trim(trailing '/' from coalesce(${events.scrapeSourceUrl}, '')), '[?#].*$', '')) = ${dedupedUrl}`,
-			)
-			.limit(1);
+function eventUrls(event: ComparableEvent) {
+	return new Set(
+		[
+			event.websiteUrl,
+			event.scrapeSourceUrl,
+			event.devpostUrl,
+			event.registrationUrl,
+		]
+			.map(canonicalizeEventUrl)
+			.filter((url): url is string => Boolean(url)),
+	);
+}
 
-		if (sourceUrlMatch.length > 0) {
-			console.info(
-				`[deduplicator] Duplicate found (scrapeSourceUrl match): ${normalized.websiteUrl}`,
-			);
+function datesWithinHours(
+	left: Date | null | undefined,
+	right: Date | null | undefined,
+	hours: number,
+) {
+	if (!left || !right) return false;
+	return Math.abs(left.getTime() - right.getTime()) <= hours * 60 * 60 * 1000;
+}
+
+function locationRelationship(
+	left: ComparableEvent,
+	right: ComparableEvent,
+): "same" | "unknown" | "conflict" {
+	if (left.format === "virtual" && right.format === "virtual") return "same";
+	if (
+		(left.format === "virtual" && right.format === "in-person") ||
+		(left.format === "in-person" && right.format === "virtual")
+	) {
+		return "conflict";
+	}
+
+	const leftCountry = normalizeText(left.country ?? "");
+	const rightCountry = normalizeText(right.country ?? "");
+	if (leftCountry && rightCountry && leftCountry !== rightCountry) {
+		return "conflict";
+	}
+
+	const leftCity = normalizeText(left.city ?? "");
+	const rightCity = normalizeText(right.city ?? "");
+	if (leftCity && rightCity && leftCity !== rightCity) return "conflict";
+	if (leftCity && rightCity && leftCity === rightCity) return "same";
+	if (leftCity || rightCity) return "unknown";
+	if (leftCountry && rightCountry && leftCountry === rightCountry)
+		return "same";
+
+	return "unknown";
+}
+
+function compareEvents(
+	incoming: ComparableEvent,
+	existing: ComparableEvent,
+): Match | null {
+	const incomingExternalIdentity = externalIdentity(incoming);
+	const existingExternalIdentity = externalIdentity(existing);
+	if (
+		incomingExternalIdentity &&
+		incomingExternalIdentity === existingExternalIdentity
+	) {
+		return {
+			action: "skip",
+			reason: "source_external_id",
+			confidence: "exact",
+			existing,
+			rank: 100,
+		};
+	}
+
+	const incomingUrls = eventUrls(incoming);
+	const existingUrls = eventUrls(existing);
+	for (const url of incomingUrls) {
+		if (existingUrls.has(url)) {
+			if (
+				incoming.startDate &&
+				existing.startDate &&
+				!datesWithinHours(incoming.startDate, existing.startDate, 72)
+			) {
+				return {
+					action: "review",
+					reason: "canonical_url_date_conflict",
+					confidence: "possible",
+					existing,
+					rank: 70,
+				};
+			}
 			return {
-				isNew: false,
-				existingId: sourceUrlMatch[0].id,
-				action: "update",
+				action: "skip",
+				reason: "canonical_url",
+				confidence: "exact",
+				existing,
+				rank: 90,
 			};
 		}
 	}
 
-	// Pass 3: Fuzzy name match within date window
-	if (normalized.startDate && normalized.name) {
-		const threeDaysBefore = new Date(normalized.startDate);
-		threeDaysBefore.setDate(threeDaysBefore.getDate() - 3);
-		const threeDaysAfter = new Date(normalized.startDate);
-		threeDaysAfter.setDate(threeDaysAfter.getDate() + 3);
+	if (!incoming.startDate || !existing.startDate) return null;
+	const similarity = eventNameSimilarity(incoming.name, existing.name);
+	const location = locationRelationship(incoming, existing);
 
-		const candidates = await db
-			.select()
-			.from(events)
-			.where(
-				and(
-					gte(events.startDate, threeDaysBefore),
-					lte(events.startDate, threeDaysAfter),
-				),
-			);
-
-		const normalizedName = normalizeForComparison(normalized.name);
-
-		for (const candidate of candidates) {
-			const candidateName = normalizeForComparison(candidate.name);
-			const distance = robustNameDistance(normalizedName, candidateName);
-
-			if (distance < 0.2) {
-				console.info(
-					`[deduplicator] Duplicate found (fuzzy match): "${normalized.name}" ≈ "${candidate.name}" (distance: ${distance.toFixed(3)})`,
-				);
-				return { isNew: false, existingId: candidate.id, action: "update" };
-			}
-		}
+	if (
+		similarity >= 0.9 &&
+		datesWithinHours(incoming.startDate, existing.startDate, 6) &&
+		location === "same"
+	) {
+		return {
+			action: "skip",
+			reason: "name_date_location",
+			confidence: "high",
+			existing,
+			rank: 80 + similarity,
+		};
 	}
 
-	return { isNew: true, action: "insert" };
-}
-
-/**
- * Filter an array of normalized events to only those that are not already in
- * the database. Checks each event via findDuplicate and returns only new ones.
- */
-export async function deduplicateAgainstDB(
-	normalized: NewEvent[],
-): Promise<NewEvent[]> {
-	const newEvents: NewEvent[] = [];
-
-	for (const event of normalized) {
-		const sourceType = (event.scrapeSource ?? "other") as SourceType;
-		const sourceUrl = event.scrapeSourceUrl ?? event.websiteUrl ?? "";
-		const result = await findDuplicate(event, sourceType, sourceUrl);
-		if (result.isNew) {
-			newEvents.push(event);
-		}
+	if (
+		similarity >= 0.78 &&
+		datesWithinHours(incoming.startDate, existing.startDate, 72) &&
+		location !== "conflict"
+	) {
+		return {
+			action: "review",
+			reason: "ambiguous_name_date",
+			confidence: "possible",
+			existing,
+			rank: 50 + similarity,
+		};
 	}
 
-	console.info(
-		`[deduplicateAgainstDB] ${normalized.length} in → ${newEvents.length} new`,
-	);
-	return newEvents;
-}
-
-/**
- * Check whether a normalized event already exists in the current in-flight
- * batch (same scraper run). This catches same-URL or near-identical name+date
- * duplicates that appear across different source URLs within the same run
- * before they are both inserted into the DB.
- *
- * Returns the existing batch entry's id if a duplicate is found, null otherwise.
- */
-export function findInBatch(
-	normalized: NewEvent,
-	batch: Array<{
-		id: string;
-		normalized: NewEvent;
-		sourceType: SourceType;
-		sourceUrl: string;
-	}>,
-): string | null {
-	for (const b of batch) {
-		// URL match
-		if (
-			normalized.websiteUrl &&
-			b.normalized.websiteUrl &&
-			normalized.websiteUrl === b.normalized.websiteUrl
-		) {
-			return b.id;
-		}
-
-		// Fuzzy name + close date
-		if (
-			normalized.startDate &&
-			b.normalized.startDate &&
-			normalized.name &&
-			b.normalized.name
-		) {
-			const dateDiff = Math.abs(
-				differenceInDays(normalized.startDate, b.normalized.startDate),
-			);
-			if (dateDiff <= 3) {
-				const dist = robustNameDistance(
-					normalizeForComparison(normalized.name),
-					normalizeForComparison(b.normalized.name),
-				);
-				if (dist < 0.2) return b.id;
-			}
-		}
-	}
 	return null;
+}
+
+function bestMatch(incoming: ComparableEvent, existing: ComparableEvent[]) {
+	let best: Match | null = null;
+	for (const candidate of existing) {
+		const match = compareEvents(incoming, candidate);
+		if (match && (!best || match.rank > best.rank)) best = match;
+	}
+	return best;
+}
+
+function matchEvidence(
+	incoming: ComparableEvent,
+	existing: ComparableEvent,
+): NonNullable<DeduplicationDecision["evidence"]> {
+	return {
+		startDate: incoming.startDate?.toISOString(),
+		country: incoming.country,
+		city: incoming.city,
+		url: [...eventUrls(incoming)][0],
+		matchedStartDate: existing.startDate?.toISOString(),
+		matchedCountry: existing.country,
+		matchedCity: existing.city,
+		matchedUrl: [...eventUrls(existing)][0],
+	};
+}
+
+function shortIdentityHash(event: ComparableEvent) {
+	const identity =
+		externalIdentity(event) ??
+		[...eventUrls(event)][0] ??
+		`${normalizeText(event.name)}:${event.startDate?.toISOString() ?? "undated"}:${event.country ?? ""}:${event.city ?? ""}`;
+	return createHash("sha256").update(identity).digest("hex").slice(0, 12);
+}
+
+function allocateSlug(event: NewEvent, usedSlugs: Set<string>) {
+	const base = event.slug ?? "event";
+	if (!usedSlugs.has(base)) {
+		usedSlugs.add(base);
+		return base;
+	}
+
+	const year = event.startDate?.getUTCFullYear();
+	const country = event.country?.toLowerCase();
+	const readableSuffix = [year, country].filter(Boolean).join("-");
+	const readable = readableSuffix ? `${base}-${readableSuffix}` : base;
+	if (!usedSlugs.has(readable)) {
+		usedSlugs.add(readable);
+		return readable;
+	}
+
+	const hashed = `${readable}-${shortIdentityHash(event)}`;
+	usedSlugs.add(hashed);
+	return hashed;
+}
+
+function newEventId(event: NewEvent) {
+	return typeof event.id === "string" ? event.id : undefined;
+}
+
+export function deduplicateEvents(
+	incoming: NewEvent[],
+	existing: ComparableEvent[],
+): DeduplicationReport {
+	const decisions: DeduplicationDecision[] = [];
+	const newEvents: NewEvent[] = [];
+	const acceptedBatch: ComparableEvent[] = [];
+	const usedSlugs = new Set(
+		existing
+			.map((event) => event.slug)
+			.filter((slug): slug is string => !!slug),
+	);
+
+	for (const [index, event] of incoming.entries()) {
+		const match = bestMatch(event as ComparableEvent, [
+			...existing,
+			...acceptedBatch,
+		]);
+
+		if (match) {
+			decisions.push({
+				index,
+				eventId: newEventId(event),
+				name: event.name,
+				action: match.action,
+				reason: match.reason,
+				confidence: match.confidence,
+				matchedEventId: match.existing.id,
+				matchedEventName: match.existing.name,
+				evidence: matchEvidence(event as ComparableEvent, match.existing),
+			});
+			continue;
+		}
+
+		const slug = allocateSlug(event, usedSlugs);
+		const prepared = { ...event, slug };
+		newEvents.push(prepared);
+		acceptedBatch.push({
+			...(prepared as ComparableEvent),
+			id: `batch:${index}`,
+		});
+		decisions.push({
+			index,
+			eventId: newEventId(event),
+			name: event.name,
+			action: "insert",
+			reason: "new_event",
+			confidence: "exact",
+			slug,
+		});
+	}
+
+	return {
+		newEvents,
+		decisions,
+		summary: {
+			total: incoming.length,
+			new: newEvents.length,
+			duplicates: decisions.filter((decision) => decision.action === "skip")
+				.length,
+			needsReview: decisions.filter((decision) => decision.action === "review")
+				.length,
+		},
+	};
+}
+
+export function auditEventCollection(
+	collection: ComparableEvent[],
+): DuplicateAuditReport {
+	const accepted: ComparableEvent[] = [];
+	const decisions: DeduplicationDecision[] = [];
+
+	for (const [index, event] of collection.entries()) {
+		const match = bestMatch(event, accepted);
+		if (match) {
+			decisions.push({
+				index,
+				eventId: event.id,
+				name: event.name,
+				action: match.action,
+				reason: match.reason,
+				confidence: match.confidence,
+				matchedEventId: match.existing.id,
+				matchedEventName: match.existing.name,
+				evidence: matchEvidence(event, match.existing),
+			});
+			if (match.action === "review") accepted.push(event);
+			continue;
+		}
+
+		accepted.push(event);
+		decisions.push({
+			index,
+			eventId: event.id,
+			name: event.name,
+			action: "insert",
+			reason: "new_event",
+			confidence: "exact",
+		});
+	}
+
+	return {
+		decisions,
+		summary: {
+			total: collection.length,
+			unique: accepted.length,
+			duplicates: decisions.filter((decision) => decision.action === "skip")
+				.length,
+			needsReview: decisions.filter((decision) => decision.action === "review")
+				.length,
+		},
+	};
+}
+
+async function loadExistingEvents(): Promise<ComparableEvent[]> {
+	return db
+		.select({
+			id: events.id,
+			slug: events.slug,
+			name: events.name,
+			startDate: events.startDate,
+			format: events.format,
+			country: events.country,
+			city: events.city,
+			websiteUrl: events.websiteUrl,
+			registrationUrl: events.registrationUrl,
+			devpostUrl: events.devpostUrl,
+			scrapeSource: events.scrapeSource,
+			scrapeSourceUrl: events.scrapeSourceUrl,
+			externalId: sql<
+				string | null
+			>`${events.scrapeRawData} ->> 'externalId'`.as("external_id"),
+		})
+		.from(events);
+}
+
+export async function deduplicateAgainstDBWithReport(
+	normalized: NewEvent[],
+): Promise<DeduplicationReport> {
+	const existing = await loadExistingEvents();
+	return deduplicateEvents(normalized, existing);
 }

--- a/lib/scraper/latam-filter.ts
+++ b/lib/scraper/latam-filter.ts
@@ -130,6 +130,7 @@ export const LATAM_CITIES: Record<string, string> = {
 	campinas: "BR",
 	florianópolis: "BR",
 	florianopolis: "BR",
+	"nova lima": "BR",
 
 	// Chile
 	santiago: "CL",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
 	"scripts": {
 		"build": "next build",
 		"check": "biome check",
+		"audit:duplicates": "bun run scripts/audit-event-duplicates.ts",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:push": "drizzle-kit push",

--- a/scripts/audit-event-duplicates.ts
+++ b/scripts/audit-event-duplicates.ts
@@ -1,0 +1,72 @@
+import "dotenv/config";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { events } from "@/lib/db/schema";
+import { checkEventConsistency } from "@/lib/ingestion/consistency";
+import { auditEventCollection } from "@/lib/scraper/deduplicator";
+
+async function main() {
+	const existing = await db
+		.select({
+			id: events.id,
+			slug: events.slug,
+			name: events.name,
+			startDate: events.startDate,
+			endDate: events.endDate,
+			registrationDeadline: events.registrationDeadline,
+			format: events.format,
+			country: events.country,
+			city: events.city,
+			websiteUrl: events.websiteUrl,
+			registrationUrl: events.registrationUrl,
+			devpostUrl: events.devpostUrl,
+			scrapeSource: events.scrapeSource,
+			scrapeSourceUrl: events.scrapeSourceUrl,
+			externalId: sql<
+				string | null
+			>`${events.scrapeRawData} ->> 'externalId'`.as("external_id"),
+		})
+		.from(events);
+	const duplicateReport = auditEventCollection(existing);
+	const duplicateFindings = duplicateReport.decisions.filter(
+		(decision) => decision.action !== "insert",
+	);
+	const consistencyFindings = existing
+		.map((event) => ({
+			eventId: event.id,
+			name: event.name,
+			...checkEventConsistency(event),
+		}))
+		.filter((result) => result.issues.length > 0);
+
+	console.log(
+		JSON.stringify(
+			{
+				mode: "read-only",
+				duplicates: {
+					...duplicateReport.summary,
+					findings: duplicateFindings.slice(0, 100),
+					reportTruncated: duplicateFindings.length > 100,
+				},
+				consistency: {
+					withIssues: consistencyFindings.length,
+					rejected: consistencyFindings.filter(
+						(result) => result.status === "reject",
+					).length,
+					needsReview: consistencyFindings.filter(
+						(result) => result.status === "review",
+					).length,
+					findings: consistencyFindings.slice(0, 100),
+					reportTruncated: consistencyFindings.length > 100,
+				},
+			},
+			null,
+			2,
+		),
+	);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/trigger/event-import.ts
+++ b/trigger/event-import.ts
@@ -10,9 +10,11 @@ import {
 	type LumaExtractedData,
 } from "@/lib/scraper/luma-schema";
 import { createUniqueSlug } from "@/lib/slug-utils";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const eventImportTask = task({
 	id: "event-import",
+	queue: eventIngestionQueue,
 	maxDuration: 120,
 	run: async (payload: {
 		jobId: string;

--- a/trigger/event-ingestion-queue.ts
+++ b/trigger/event-ingestion-queue.ts
@@ -1,0 +1,6 @@
+import { queue } from "@trigger.dev/sdk/v3";
+
+export const eventIngestionQueue = queue({
+	name: "event-ingestion",
+	concurrencyLimit: 1,
+});

--- a/trigger/luma-calendar-sync.ts
+++ b/trigger/luma-calendar-sync.ts
@@ -1,8 +1,10 @@
 import { metadata, schedules } from "@trigger.dev/sdk/v3";
 import { syncLumaCalendarEvents } from "@/lib/luma/calendar-sync";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const lumaCalendarSyncTask = schedules.task({
 	id: "luma-calendar-sync",
+	queue: eventIngestionQueue,
 	cron: "0 * * * *",
 	maxDuration: 300,
 	run: async () => {

--- a/trigger/luma-webhook-processor.ts
+++ b/trigger/luma-webhook-processor.ts
@@ -16,6 +16,7 @@ import {
 	ensureUniqueShortCode,
 	generateSlug,
 } from "@/lib/slug-utils";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 async function fetchLumaEventDetails(
 	eventId: string,
@@ -280,6 +281,7 @@ async function resolveOrCreateOrganization(
 
 export const lumaWebhookProcessorTask = task({
 	id: "luma-webhook-processor",
+	queue: eventIngestionQueue,
 	maxDuration: 120,
 	run: async (payload: LumaWebhookTaskPayload) => {
 		const { event_type, data } = payload;

--- a/trigger/scrapers/devpost-scraper.ts
+++ b/trigger/scrapers/devpost-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeDevpost } from "@/lib/scraper/sources/devpost";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const devpostScraperTask = task({
 	id: "devpost-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 600,
 	run: async (payload: IngestionTaskPayload) => {
 		const mode = ingestionModeFromWriteFlag(payload?.write);

--- a/trigger/scrapers/eventbrite-scraper.ts
+++ b/trigger/scrapers/eventbrite-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeEventbrite } from "@/lib/scraper/sources/eventbrite";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const eventbriteScraperTask = task({
 	id: "eventbrite-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 600,
 	run: async (payload: IngestionTaskPayload) => {
 		const mode = ingestionModeFromWriteFlag(payload?.write);

--- a/trigger/scrapers/exa-scraper.ts
+++ b/trigger/scrapers/exa-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeExa } from "@/lib/scraper/sources/exa";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const exaScraperTask = task({
 	id: "exa-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 300,
 	retry: {
 		maxAttempts: 2,

--- a/trigger/scrapers/hackathon-com-scraper.ts
+++ b/trigger/scrapers/hackathon-com-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeHackathonCom } from "@/lib/scraper/sources/hackathon-com";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const hackathonComScraperTask = task({
 	id: "hackathon-com-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 300,
 	retry: {
 		maxAttempts: 2,

--- a/trigger/scrapers/haiku-scraper.ts
+++ b/trigger/scrapers/haiku-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeHaiku } from "@/lib/scraper/sources/haiku";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const haikuScraperTask = task({
 	id: "haiku-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 300,
 	retry: {
 		maxAttempts: 2,

--- a/trigger/scrapers/meetup-scraper.ts
+++ b/trigger/scrapers/meetup-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeMeetup } from "@/lib/scraper/sources/meetup";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const meetupScraperTask = task({
 	id: "meetup-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 300,
 	run: async (payload: IngestionTaskPayload) => {
 		const mode = ingestionModeFromWriteFlag(payload?.write);

--- a/trigger/scrapers/mlh-scraper.ts
+++ b/trigger/scrapers/mlh-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeMlh } from "@/lib/scraper/sources/mlh";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const mlhScraperTask = task({
 	id: "mlh-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 300,
 	run: async (payload: IngestionTaskPayload) => {
 		const mode = ingestionModeFromWriteFlag(payload?.write);

--- a/trigger/scrapers/perplexity-scraper.ts
+++ b/trigger/scrapers/perplexity-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapePerplexity } from "@/lib/scraper/sources/perplexity";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const perplexityScraperTask = task({
 	id: "perplexity-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 300,
 	retry: {
 		maxAttempts: 2,

--- a/trigger/scrapers/universities-scraper.ts
+++ b/trigger/scrapers/universities-scraper.ts
@@ -6,9 +6,11 @@ import {
 } from "@/lib/ingestion/safety";
 import { runPostProcessor } from "@/lib/scraper/post-processor";
 import { scrapeUniversities } from "@/lib/scraper/sources/universities";
+import { eventIngestionQueue } from "@/trigger/event-ingestion-queue";
 
 export const universitiesScraperTask = task({
 	id: "universities-scraper",
+	queue: eventIngestionQueue,
 	maxDuration: 600,
 	retry: {
 		maxAttempts: 2,


### PR DESCRIPTION
## What changed

- replaces slug-based duplicate detection with layered identity matching
- canonicalizes event URLs and strips tracking parameters
- matches exact provider IDs and event URLs, while treating reused URLs with conflicting dates as review cases
- requires compatible dates and locations for high-confidence fuzzy matches
- holds ambiguous and inconsistent candidates instead of inserting them
- allocates deterministic collision-safe slugs for distinct events with the same name
- adds evidence-rich ingestion reports and a read-only database audit command
- serializes all Trigger event-writing tasks through one shared queue
- documents the per-source canary, validation, and Trigger activation gate

## Why

The previous matcher treated a shared slug as proof of identity and used only name plus a three-day window for fuzzy matches. That could merge separate city or annual editions, while concurrent source tasks could deduplicate against the same stale database snapshot.

## Read-only production audit

`bun run audit:duplicates` inspected 215 existing events without modifying data or calling external provider APIs.

- 0 automatic duplicates
- 4 possible pairs held for human review
- 3 country inconsistencies: El Salvador, Bogotá, and Ciudad de Guatemala are currently stored as Peru
- the Nova Lima, Brazil false positive found during review was fixed in the location dictionary

Manual review of public Luma pages found:

- The Next Craft city editions are separate events and must not be merged.
- `Zero to Agent: Lima` and `Zero to Agent: Lima - PUCP` describe the same date and PUCP venue, so this is a confirmed historical duplicate.
- the two Buenos Aires records share title, venue, and one host but differ by about 23 hours, so they remain ambiguous.

No event was updated, deleted, or inserted. Historical cleanup requires a separate explicit approval.

## Validation

- `bun run test:ingestion` (29 passing)
- `bunx tsc --noEmit --pretty false`
- `bun run build`
- targeted Biome checks on all changed files
- `git diff --check`

The repository-wide `bun run check` still fails on pre-existing unrelated Biome findings in `scripts/test-scraper.ts`, admin components, and Lexical plugins.

## Checkpoint

Review and merge this foundation before implementing secure two-way Hack0-Luma synchronization. This phase does not deploy Trigger.dev because it introduces no new source.