### PR TITLE
fix(ingestion): remediate audited event data

### DIFF
--- a/docs/event-ingestion-rollout.md
+++ b/docs/event-ingestion-rollout.md
@@ -81,3 +81,22 @@ bun run audit:duplicates
 
 The command only selects the event identity fields required by the matcher. It
 does not call external source APIs and does not insert, update, or delete rows.
+Duplicate and consistency results cover the approved public index; the report
+also shows how many historical, pending, or rejected rows were excluded.
+
+## Manual source suppression
+
+Confirmed duplicate source URLs that could be re-approved by a direct provider
+sync are recorded in `lib/ingestion/manual-overrides.ts`. A suppression must
+name its canonical event and explain the reason. The historical duplicate row
+is retained as rejected for auditability instead of being hard-deleted.
+
+One-off reviewed data corrections use:
+
+```bash
+bun run remediate:event-audit
+```
+
+The command defaults to dry-run and verifies exact IDs and prior values before
+any update. Production execution additionally requires all write-safety
+environment confirmations.

--- a/lib/geo/latam-location.ts
+++ b/lib/geo/latam-location.ts
@@ -1,0 +1,54 @@
+import { LATAM_CITIES, LATAM_COUNTRY_NAMES } from "@/lib/scraper/latam-filter";
+
+export interface InferredLatamLocation {
+	country: string;
+	city: string | null;
+}
+
+function normalizeLocationText(value: string) {
+	return ` ${value
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()} `;
+}
+
+function formatCityName(value: string) {
+	const lowercaseWords = new Set(["de", "del", "la", "las", "los"]);
+	return value
+		.split(" ")
+		.map((word, index) => {
+			if (index > 0 && lowercaseWords.has(word)) return word;
+			return `${word.charAt(0).toLocaleUpperCase()}${word.slice(1)}`;
+		})
+		.join(" ");
+}
+
+const LATAM_PLACES = [
+	...Object.entries(LATAM_CITIES).map(([name, country]) => ({
+		name,
+		country,
+		city: formatCityName(name),
+	})),
+	...Object.entries(LATAM_COUNTRY_NAMES).map(([name, country]) => ({
+		name,
+		country,
+		city: null,
+	})),
+].sort((left, right) => right.name.length - left.name.length);
+
+export function inferLatamLocationFromText(
+	...values: Array<string | null | undefined>
+): InferredLatamLocation | null {
+	const haystack = normalizeLocationText(values.filter(Boolean).join(" "));
+	if (haystack.trim().length === 0) return null;
+
+	for (const place of LATAM_PLACES) {
+		if (haystack.includes(normalizeLocationText(place.name))) {
+			return { country: place.country, city: place.city };
+		}
+	}
+
+	return null;
+}

--- a/lib/ingestion/__tests__/manual-overrides.test.ts
+++ b/lib/ingestion/__tests__/manual-overrides.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { inferLatamLocationFromText } from "@/lib/geo/latam-location";
+import { getEventSourceSuppression } from "@/lib/ingestion/manual-overrides";
+import { resolveLumaEventLocation } from "@/lib/luma/location";
+
+describe("inferLatamLocationFromText", () => {
+	test("uses the longest matching place name", () => {
+		assert.deepEqual(inferLatamLocationFromText("Café Cursor Nova Lima"), {
+			country: "BR",
+			city: "Nova Lima",
+		});
+	});
+
+	test("infers countries and cities used by Luma titles", () => {
+		assert.deepEqual(
+			inferLatamLocationFromText("[Ciudad de Guatemala] Full day Hackathon"),
+			{ country: "GT", city: "Ciudad de Guatemala" },
+		);
+		assert.deepEqual(
+			inferLatamLocationFromText("[El Salvador] Full day Hackathon"),
+			{ country: "SV", city: null },
+		);
+	});
+});
+
+describe("resolveLumaEventLocation", () => {
+	test("prefers a LATAM place in the title over the country fallback", () => {
+		assert.deepEqual(
+			resolveLumaEventLocation({
+				eventName: "[Bogotá] Full day Hackathon",
+				countryFallback: "PE",
+			}),
+			{
+				format: "in-person",
+				country: "CO",
+				department: null,
+				city: "Bogotá",
+				venue: null,
+				geoLatitude: null,
+				geoLongitude: null,
+			},
+		);
+	});
+});
+
+describe("getEventSourceSuppression", () => {
+	test("matches canonical Luma URL aliases and tracking parameters", () => {
+		const suppression = getEventSourceSuppression(
+			"https://www.lu.ma/hveetdob?utm_source=test",
+		);
+
+		assert.equal(
+			suppression?.canonicalEventId,
+			"19846e8e-c0aa-49d2-a5d9-f0c6546e7407",
+		);
+	});
+
+	test("does not suppress unrelated sources", () => {
+		assert.equal(getEventSourceSuppression("https://luma.com/yn7nc6id"), null);
+	});
+});

--- a/lib/ingestion/consistency.ts
+++ b/lib/ingestion/consistency.ts
@@ -1,4 +1,4 @@
-import { LATAM_CITIES, LATAM_COUNTRY_NAMES } from "@/lib/scraper/latam-filter";
+import { inferLatamLocationFromText } from "@/lib/geo/latam-location";
 
 export type ConsistencySeverity = "warning" | "review" | "reject";
 export type ConsistencyIssueCode =
@@ -27,28 +27,6 @@ export interface ConsistencyIssue {
 export interface ConsistencyResult {
 	status: "valid" | "review" | "reject";
 	issues: ConsistencyIssue[];
-}
-
-function normalizeLocationText(value: string) {
-	return ` ${value
-		.toLowerCase()
-		.normalize("NFD")
-		.replace(/[\u0300-\u036f]/g, "")
-		.replace(/[^a-z0-9]+/g, " ")
-		.trim()} `;
-}
-
-function inferCountryFromName(name: string) {
-	const normalizedName = normalizeLocationText(name);
-	const places = [
-		...Object.entries(LATAM_COUNTRY_NAMES),
-		...Object.entries(LATAM_CITIES),
-	].sort(([left], [right]) => right.length - left.length);
-
-	for (const [place, country] of places) {
-		if (normalizedName.includes(normalizeLocationText(place))) return country;
-	}
-	return null;
 }
 
 export function checkEventConsistency(
@@ -100,7 +78,7 @@ export function checkEventConsistency(
 		});
 	}
 
-	const countryFromName = inferCountryFromName(event.name);
+	const countryFromName = inferLatamLocationFromText(event.name)?.country;
 	if (
 		event.country &&
 		countryFromName &&

--- a/lib/ingestion/manual-overrides.ts
+++ b/lib/ingestion/manual-overrides.ts
@@ -1,0 +1,26 @@
+import { canonicalizeEventUrl } from "@/lib/scraper/deduplicator";
+
+export interface EventSourceSuppression {
+	reason: "duplicate";
+	canonicalEventId: string;
+	note: string;
+}
+
+const EVENT_SOURCE_SUPPRESSIONS = new Map<string, EventSourceSuppression>([
+	[
+		"luma.com/hveetdob",
+		{
+			reason: "duplicate",
+			canonicalEventId: "19846e8e-c0aa-49d2-a5d9-f0c6546e7407",
+			note: "Duplicate listing for Zero to Agent: Lima",
+		},
+	],
+]);
+
+export function getEventSourceSuppression(
+	url: string | null | undefined,
+): EventSourceSuppression | null {
+	const canonicalUrl = canonicalizeEventUrl(url);
+	if (!canonicalUrl) return null;
+	return EVENT_SOURCE_SUPPRESSIONS.get(canonicalUrl) ?? null;
+}

--- a/lib/luma/calendar-sync.ts
+++ b/lib/luma/calendar-sync.ts
@@ -1,6 +1,7 @@
 import { and, eq, notInArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { eventHosts, events, organizations } from "@/lib/db/schema";
+import { getEventSourceSuppression } from "@/lib/ingestion/manual-overrides";
 import { assertWriteAllowed } from "@/lib/ingestion/safety";
 import { resolveLumaEventLocation } from "@/lib/luma/location";
 import { inferEventType } from "@/lib/scraper/luma-schema";
@@ -368,6 +369,16 @@ async function syncEvent(
 	fallbackHosts: LumaHost[],
 	apiKey: string,
 ) {
+	const suppression = getEventSourceSuppression(event.url);
+	if (suppression) {
+		return {
+			name: event.name,
+			url: event.url,
+			action: "skipped" as const,
+			reason: `suppressed_${suppression.reason}:${suppression.canonicalEventId}`,
+		};
+	}
+
 	if (shouldSkipEvent(event)) {
 		return {
 			name: event.name,

--- a/lib/luma/location.ts
+++ b/lib/luma/location.ts
@@ -1,4 +1,5 @@
 import { normalizeCountryCode } from "@/lib/event-utils";
+import { inferLatamLocationFromText } from "@/lib/geo/latam-location";
 
 type LumaGeoAddress = {
 	city?: string | null;
@@ -173,14 +174,6 @@ function hasVirtualLocationSignal(...values: Array<string | null | undefined>) {
 	].some((pattern) => haystack.includes(pattern));
 }
 
-function normalizeCity(
-	value: string | null | undefined,
-	fallback?: string | null,
-) {
-	const place = inferPeruPlace(value);
-	return place?.city || cleanText(value) || fallback || null;
-}
-
 function normalizeDepartment(
 	value: string | null | undefined,
 	fallback?: string | null,
@@ -231,17 +224,31 @@ export function resolveLumaEventLocation(
 		geo?.address,
 		geo?.full_address,
 	);
-	const inferredPlace = inferPeruPlace(
+	const inferredLatamLocation = inferLatamLocationFromText(
 		input.eventName,
 		geo?.city,
 		geo?.region,
 		geo?.city_state,
 		venue,
 	);
-	const city = normalizeCity(geo?.city, inferredPlace?.city);
+	const inferredPeruPlace =
+		inferredLatamLocation?.country === "PE"
+			? inferPeruPlace(
+					input.eventName,
+					geo?.city,
+					geo?.region,
+					geo?.city_state,
+					venue,
+				)
+			: null;
+	const city =
+		cleanText(geo?.city) ||
+		inferredLatamLocation?.city ||
+		inferredPeruPlace?.city ||
+		null;
 	const department = normalizeDepartment(
 		geo?.region,
-		inferredPlace?.department,
+		inferredPeruPlace?.department,
 	);
 	const meetingUrl = cleanText(input.meetingUrl);
 	const locationType = locationTypeFrom(input, geo);
@@ -256,6 +263,7 @@ export function resolveLumaEventLocation(
 	);
 	const country =
 		normalizeCountryCode(geo?.country_code || geo?.country || null) ||
+		inferredLatamLocation?.country ||
 		input.countryFallback ||
 		"PE";
 	const format = resolveFormat(

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
 		"lint:fix": "biome lint --write",
 		"migrate:personal-orgs": "bun run scripts/migrate-personal-orgs.ts",
 		"prepare": "simple-git-hooks",
+		"remediate:event-audit": "bun run scripts/remediate-event-audit-findings.ts",
 		"seed:ecosystem-websites": "bun run scripts/seed-ecosystem-websites.ts",
 		"seed:peru-universities": "bun run scripts/seed-peru-universities.ts",
 		"sync:devpost": "bun run scripts/sync-devpost.ts",

--- a/scripts/audit-event-duplicates.ts
+++ b/scripts/audit-event-duplicates.ts
@@ -22,16 +22,21 @@ async function main() {
 			devpostUrl: events.devpostUrl,
 			scrapeSource: events.scrapeSource,
 			scrapeSourceUrl: events.scrapeSourceUrl,
+			isApproved: events.isApproved,
+			approvalStatus: events.approvalStatus,
 			externalId: sql<
 				string | null
 			>`${events.scrapeRawData} ->> 'externalId'`.as("external_id"),
 		})
 		.from(events);
-	const duplicateReport = auditEventCollection(existing);
+	const publicEvents = existing.filter(
+		(event) => event.isApproved === true && event.approvalStatus === "approved",
+	);
+	const duplicateReport = auditEventCollection(publicEvents);
 	const duplicateFindings = duplicateReport.decisions.filter(
 		(decision) => decision.action !== "insert",
 	);
-	const consistencyFindings = existing
+	const consistencyFindings = publicEvents
 		.map((event) => ({
 			eventId: event.id,
 			name: event.name,
@@ -43,6 +48,11 @@ async function main() {
 		JSON.stringify(
 			{
 				mode: "read-only",
+				scope: {
+					databaseEvents: existing.length,
+					publicIndexEvents: publicEvents.length,
+					excludedFromPublicIndex: existing.length - publicEvents.length,
+				},
 				duplicates: {
 					...duplicateReport.summary,
 					findings: duplicateFindings.slice(0, 100),

--- a/scripts/remediate-event-audit-findings.ts
+++ b/scripts/remediate-event-audit-findings.ts
@@ -1,0 +1,199 @@
+import "dotenv/config";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { events } from "@/lib/db/schema";
+import { assertWriteAllowed, parseIngestionMode } from "@/lib/ingestion/safety";
+
+const COUNTRY_FIXES = [
+	{
+		id: "92c0e905-74e7-4391-a0e4-d30bd71b0765",
+		name: "[El Salvador] Full day Hackathon: The next craft",
+		fromCountry: "PE",
+		fromCity: null,
+		toCountry: "SV",
+		toCity: null,
+	},
+	{
+		id: "baac7b81-3ae3-4e4c-adf6-4bb9f8f5235b",
+		name: "[Bogotá] Full day Hackathon: The next craft",
+		fromCountry: "PE",
+		fromCity: null,
+		toCountry: "CO",
+		toCity: "Bogotá",
+	},
+	{
+		id: "9f44e766-f7bf-4514-98d0-eca8b54d54c3",
+		name: "[Ciudad de Guatemala] Full day Hackathon: The next craft",
+		fromCountry: "PE",
+		fromCity: null,
+		toCountry: "GT",
+		toCity: "Ciudad de Guatemala",
+	},
+] as const;
+
+const DUPLICATE_FIX = {
+	id: "4baa8071-4786-4249-b616-6650b798a224",
+	name: "Zero to Agent: Lima - PUCP",
+	websiteUrl: "https://luma.com/hveetdob",
+	canonicalEventId: "19846e8e-c0aa-49d2-a5d9-f0c6546e7407",
+} as const;
+
+const mode = parseIngestionMode(process.argv.slice(2));
+const targetIds = [...COUNTRY_FIXES.map((fix) => fix.id), DUPLICATE_FIX.id];
+
+async function readTargets() {
+	return db
+		.select({
+			id: events.id,
+			name: events.name,
+			country: events.country,
+			city: events.city,
+			websiteUrl: events.websiteUrl,
+			isApproved: events.isApproved,
+			approvalStatus: events.approvalStatus,
+		})
+		.from(events)
+		.where(inArray(events.id, targetIds));
+}
+
+function assertExpectedState(rows: Awaited<ReturnType<typeof readTargets>>) {
+	if (rows.length !== targetIds.length) {
+		throw new Error(
+			`Expected ${targetIds.length} target events, found ${rows.length}`,
+		);
+	}
+
+	for (const fix of COUNTRY_FIXES) {
+		const row = rows.find((event) => event.id === fix.id);
+		if (
+			!row ||
+			row.name !== fix.name ||
+			row.country !== fix.fromCountry ||
+			row.city !== fix.fromCity
+		) {
+			throw new Error(`Country target ${fix.id} is not in its expected state`);
+		}
+	}
+
+	const duplicate = rows.find((event) => event.id === DUPLICATE_FIX.id);
+	if (
+		!duplicate ||
+		duplicate.name !== DUPLICATE_FIX.name ||
+		duplicate.websiteUrl !== DUPLICATE_FIX.websiteUrl ||
+		duplicate.isApproved !== true ||
+		duplicate.approvalStatus !== "approved"
+	) {
+		throw new Error(
+			`Duplicate target ${DUPLICATE_FIX.id} is not in its expected state`,
+		);
+	}
+}
+
+function assertRemediatedState(rows: Awaited<ReturnType<typeof readTargets>>) {
+	for (const fix of COUNTRY_FIXES) {
+		const row = rows.find((event) => event.id === fix.id);
+		if (
+			!row ||
+			row.name !== fix.name ||
+			row.country !== fix.toCountry ||
+			row.city !== fix.toCity
+		) {
+			throw new Error(`Country correction was not verified for ${fix.id}`);
+		}
+	}
+
+	const duplicate = rows.find((event) => event.id === DUPLICATE_FIX.id);
+	if (
+		!duplicate ||
+		duplicate.name !== DUPLICATE_FIX.name ||
+		duplicate.websiteUrl !== DUPLICATE_FIX.websiteUrl ||
+		duplicate.isApproved !== false ||
+		duplicate.approvalStatus !== "rejected"
+	) {
+		throw new Error(
+			`Duplicate suppression was not verified for ${DUPLICATE_FIX.id}`,
+		);
+	}
+}
+
+async function applyFixes() {
+	for (const fix of COUNTRY_FIXES) {
+		const updated = await db
+			.update(events)
+			.set({
+				country: fix.toCountry,
+				city: fix.toCity,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(events.id, fix.id),
+					eq(events.name, fix.name),
+					eq(events.country, fix.fromCountry),
+				),
+			)
+			.returning({ id: events.id });
+
+		if (updated.length !== 1) {
+			throw new Error(`Country update failed for ${fix.id}`);
+		}
+	}
+
+	const hidden = await db
+		.update(events)
+		.set({
+			isApproved: false,
+			approvalStatus: "rejected",
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(events.id, DUPLICATE_FIX.id),
+				eq(events.name, DUPLICATE_FIX.name),
+				eq(events.websiteUrl, DUPLICATE_FIX.websiteUrl),
+				eq(events.isApproved, true),
+				eq(events.approvalStatus, "approved"),
+			),
+		)
+		.returning({ id: events.id });
+
+	if (hidden.length !== 1) {
+		throw new Error(`Duplicate update failed for ${DUPLICATE_FIX.id}`);
+	}
+}
+
+async function main() {
+	assertWriteAllowed(mode);
+	const before = await readTargets();
+	assertExpectedState(before);
+
+	const changes = {
+		countries: COUNTRY_FIXES.map((fix) => ({
+			id: fix.id,
+			name: fix.name,
+			from: { country: fix.fromCountry, city: fix.fromCity },
+			to: { country: fix.toCountry, city: fix.toCity },
+		})),
+		duplicate: {
+			id: DUPLICATE_FIX.id,
+			name: DUPLICATE_FIX.name,
+			action: "hide_and_reject",
+			canonicalEventId: DUPLICATE_FIX.canonicalEventId,
+		},
+	};
+
+	if (mode === "dry-run") {
+		console.log(JSON.stringify({ mode, changes }, null, 2));
+		return;
+	}
+
+	await applyFixes();
+	const after = await readTargets();
+	assertRemediatedState(after);
+	console.log(JSON.stringify({ mode, changes, after }, null, 2));
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/trigger/luma-webhook-processor.ts
+++ b/trigger/luma-webhook-processor.ts
@@ -5,6 +5,7 @@ import { UTApi } from "uploadthing/server";
 import { db } from "@/lib/db";
 import { eventHosts, events, organizations } from "@/lib/db/schema";
 import { normalizeCountryCode } from "@/lib/event-utils";
+import { getEventSourceSuppression } from "@/lib/ingestion/manual-overrides";
 import type {
 	LumaApiEvent,
 	LumaHost,
@@ -290,6 +291,18 @@ export const lumaWebhookProcessorTask = task({
 		metadata.set("lumaEventId", data.api_id);
 		metadata.set("lumaEventName", data.name);
 		metadata.set("calendarSlug", data.calendar?.slug || "unknown");
+
+		const suppression = getEventSourceSuppression(data.url);
+		if (suppression) {
+			metadata.set("step", "event_source_suppressed");
+			metadata.set("canonicalEventId", suppression.canonicalEventId);
+			return {
+				success: true,
+				skipped: true,
+				reason: `Suppressed ${suppression.reason}`,
+				eventId: suppression.canonicalEventId,
+			};
+		}
 
 		const org = await resolveOrCreateOrganization(data);
 


### PR DESCRIPTION
## Summary
- infer LATAM country and city from Luma event titles so corrected locations stay correct
- suppress one confirmed duplicate Luma URL in calendar sync and webhooks
- add a guarded dry-run-first remediation script and public-index audit scope

## Validation
- `bun run test:ingestion` (34 passed)
- `bunx tsc --noEmit`
- `bun run build`
- production dry-run verified the four expected target rows

## Production
No production write is part of this PR. After merge, run only the reviewed remediation with explicit production write guards, then repeat the read-only audit.