### PR TITLE
fix(devpost): normalize source identity data

### DIFF
--- a/lib/ingestion/__tests__/deduplicator.test.ts
+++ b/lib/ingestion/__tests__/deduplicator.test.ts
@@ -50,6 +50,15 @@ describe("canonicalizeEventUrl", () => {
 			"events.example.com/view?id=42",
 		);
 	});
+
+	test("ignores Devpost's shared account registration page", () => {
+		assert.equal(
+			canonicalizeEventUrl(
+				"https://secure.devpost.com/users/register?ref_content=signup_global_nav",
+			),
+			null,
+		);
+	});
 });
 
 describe("eventNameSimilarity", () => {

--- a/lib/scraper/__tests__/devpost.test.ts
+++ b/lib/scraper/__tests__/devpost.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+	normalizeDevpostAssetUrl,
+	parseDevpostDateRange,
+	parseDevpostDetailPage,
+} from "@/lib/scraper/sources/devpost";
+
+describe("parseDevpostDateRange", () => {
+	test("normalizes same-month ranges", () => {
+		assert.deepEqual(parseDevpostDateRange("Jul 27 - 31, 2026"), {
+			startDate: "2026-07-27T00:00:00.000Z",
+			endDate: "2026-07-31T00:00:00.000Z",
+		});
+	});
+
+	test("normalizes cross-month ranges", () => {
+		assert.deepEqual(parseDevpostDateRange("Jul 27 - Aug 14, 2026"), {
+			startDate: "2026-07-27T00:00:00.000Z",
+			endDate: "2026-08-14T00:00:00.000Z",
+		});
+	});
+
+	test("infers the previous year for ranges crossing January", () => {
+		assert.deepEqual(parseDevpostDateRange("Dec 27 - Jan 4, 2027"), {
+			startDate: "2026-12-27T00:00:00.000Z",
+			endDate: "2027-01-04T00:00:00.000Z",
+		});
+	});
+
+	test("uses a single date for one-day events", () => {
+		assert.deepEqual(parseDevpostDateRange("Jul 28, 2026"), {
+			startDate: "2026-07-28T00:00:00.000Z",
+			endDate: "2026-07-28T00:00:00.000Z",
+		});
+	});
+
+	test("returns no dates for unknown formats", () => {
+		assert.deepEqual(parseDevpostDateRange("Coming soon"), {});
+	});
+});
+
+describe("normalizeDevpostAssetUrl", () => {
+	test("expands protocol-relative assets", () => {
+		assert.equal(
+			normalizeDevpostAssetUrl("//cdn.example.com/image.png"),
+			"https://cdn.example.com/image.png",
+		);
+	});
+
+	test("rejects relative and non-http assets", () => {
+		assert.equal(normalizeDevpostAssetUrl("/image.png"), undefined);
+		assert.equal(normalizeDevpostAssetUrl("javascript:alert(1)"), undefined);
+	});
+});
+
+describe("parseDevpostDetailPage", () => {
+	test("uses structured event and registration dates", () => {
+		const parsed = parseDevpostDetailPage(
+			`
+				<script type="application/ld+json">
+					{
+						"@type": "Event",
+						"name": "Hack0",
+						"startDate": "2026-09-20T09:00:00-05:00",
+						"endDate": "2026-09-20T18:00:00-05:00"
+					}
+				</script>
+				<div class="deadline">
+					<time datetime="2026-09-18T23:45:00-04:00">September 18</time>
+				</div>
+			`,
+			"https://hack0.devpost.com/",
+		);
+
+		assert.equal(parsed.startDate, "2026-09-20T14:00:00.000Z");
+		assert.equal(parsed.endDate, "2026-09-20T23:00:00.000Z");
+		assert.equal(parsed.registrationDeadline, "2026-09-19T03:45:00.000Z");
+	});
+
+	test("selects the event registration link instead of Devpost signup", () => {
+		const parsed = parseDevpostDetailPage(
+			`
+				<a href="https://secure.devpost.com/users/register?ref_content=nav">Sign up</a>
+				<a href="https://hack0.devpost.com/register?flow%5Bdata%5D%5Bchallenge_id%5D=42">
+					Join hackathon
+				</a>
+			`,
+			"https://hack0.devpost.com/",
+		);
+
+		assert.equal(
+			parsed.registrationUrl,
+			"https://hack0.devpost.com/register?flow%5Bdata%5D%5Bchallenge_id%5D=42",
+		);
+	});
+});

--- a/lib/scraper/deduplicator.ts
+++ b/lib/scraper/deduplicator.ts
@@ -165,6 +165,12 @@ export function canonicalizeEventUrl(value: string | null | undefined) {
 		const pathname = parsed.pathname
 			.replace(/\/{2,}/g, "/")
 			.replace(/\/+$/, "");
+		if (
+			hostname === "secure.devpost.com" &&
+			pathname.toLowerCase() === "/users/register"
+		) {
+			return null;
+		}
 
 		for (const key of [...parsed.searchParams.keys()]) {
 			const normalizedKey = key.toLowerCase();

--- a/lib/scraper/sources/devpost.ts
+++ b/lib/scraper/sources/devpost.ts
@@ -385,22 +385,86 @@ function parseDevpostApiResponse(json: unknown): {
 	return { hackathons, meta };
 }
 
-function apiHackathonToRaw(item: DevpostApiHackathon): RawHackathon {
-	let startDate: string | undefined;
-	let endDate: string | undefined;
+const MONTH_NUMBERS: Record<string, string> = {
+	jan: "01",
+	feb: "02",
+	mar: "03",
+	apr: "04",
+	may: "05",
+	jun: "06",
+	jul: "07",
+	aug: "08",
+	sep: "09",
+	oct: "10",
+	nov: "11",
+	dec: "12",
+};
 
-	if (item.submission_period_dates) {
-		const dateStr = item.submission_period_dates;
-		const dashIndex = dateStr.indexOf(" - ");
-		if (dashIndex > 0) {
-			startDate = dateStr.slice(0, dashIndex).trim();
-			endDate = dateStr.slice(dashIndex + 3).trim();
-			if (endDate.match(/\d{4}/) && !startDate.match(/\d{4}/)) {
-				const yearMatch = endDate.match(/(\d{4})/);
-				if (yearMatch) startDate = `${startDate}, ${yearMatch[1]}`;
-			}
-		}
+function isoDateFromParts(month: string, day: string, year: string) {
+	const monthNumber = MONTH_NUMBERS[month.toLowerCase().slice(0, 3)];
+	if (!monthNumber) return undefined;
+	const dayNumber = Number(day);
+	const yearNumber = Number(year);
+	if (
+		!Number.isInteger(dayNumber) ||
+		dayNumber < 1 ||
+		dayNumber > 31 ||
+		!Number.isInteger(yearNumber)
+	) {
+		return undefined;
 	}
+	return `${yearNumber.toString().padStart(4, "0")}-${monthNumber}-${dayNumber
+		.toString()
+		.padStart(2, "0")}T00:00:00.000Z`;
+}
+
+export function parseDevpostDateRange(value: string): {
+	startDate?: string;
+	endDate?: string;
+} {
+	const rangeMatch = value
+		.trim()
+		.match(
+			/^([A-Za-z]{3,9})\s+(\d{1,2})(?:,\s*(\d{4}))?\s+-\s+(?:(?:([A-Za-z]{3,9})\s+)?(\d{1,2}),\s*(\d{4}))$/,
+		);
+	if (rangeMatch) {
+		const [, startMonth, startDay, startYear, endMonth, endDay, endYear] =
+			rangeMatch;
+		const resolvedEndMonth = endMonth || startMonth;
+		const inferredStartYear =
+			!startYear &&
+			Number(MONTH_NUMBERS[resolvedEndMonth.toLowerCase().slice(0, 3)]) <
+				Number(MONTH_NUMBERS[startMonth.toLowerCase().slice(0, 3)])
+				? String(Number(endYear) - 1)
+				: endYear;
+		return {
+			startDate: isoDateFromParts(
+				startMonth,
+				startDay,
+				startYear || inferredStartYear,
+			),
+			endDate: isoDateFromParts(resolvedEndMonth, endDay, endYear),
+		};
+	}
+
+	const singleMatch = value
+		.trim()
+		.match(/^([A-Za-z]{3,9})\s+(\d{1,2}),\s*(\d{4})$/);
+	if (!singleMatch) return {};
+	const date = isoDateFromParts(singleMatch[1], singleMatch[2], singleMatch[3]);
+	return { startDate: date, endDate: date };
+}
+
+export function normalizeDevpostAssetUrl(value?: string) {
+	if (!value) return undefined;
+	if (value.startsWith("//")) return `https:${value}`;
+	return /^https?:\/\//i.test(value) ? value : undefined;
+}
+
+function apiHackathonToRaw(item: DevpostApiHackathon): RawHackathon {
+	const { startDate, endDate } = parseDevpostDateRange(
+		item.submission_period_dates,
+	);
 
 	let city: string | undefined;
 	let country: string | undefined;
@@ -481,7 +545,8 @@ function apiHackathonToRaw(item: DevpostApiHackathon): RawHackathon {
 		country,
 		eligibility: eligibilityHint,
 		websiteUrl: item.url,
-		imageUrl: item.thumbnail_url,
+		registrationUrl: item.url,
+		imageUrl: normalizeDevpostAssetUrl(item.thumbnail_url),
 		prizePool: item.prize_amount
 			? item.prize_amount.replace(/<[^>]+>/g, "").trim()
 			: undefined,
@@ -494,7 +559,7 @@ function apiHackathonToRaw(item: DevpostApiHackathon): RawHackathon {
 	};
 }
 
-function parseDevpostDetailPage(
+export function parseDevpostDetailPage(
 	html: string,
 	_url: string,
 ): Partial<RawHackathon> {
@@ -510,6 +575,17 @@ function parseDevpostDetailPage(
 			const data = JSON.parse(raw) as Record<string, unknown>;
 			const location = data.location as Record<string, unknown> | undefined;
 			const address = location?.address as Record<string, unknown> | undefined;
+			const structuredStart = data.startDate;
+			const structuredEnd = data.endDate;
+			if (typeof structuredStart === "string") {
+				const date = new Date(structuredStart);
+				if (!Number.isNaN(date.getTime()))
+					result.startDate = date.toISOString();
+			}
+			if (typeof structuredEnd === "string") {
+				const date = new Date(structuredEnd);
+				if (!Number.isNaN(date.getTime())) result.endDate = date.toISOString();
+			}
 
 			// Venue name from ld+json — only use if it's a real venue, not the event name
 			// Online events set location.name to the event title which is not useful
@@ -561,20 +637,14 @@ function parseDevpostDetailPage(
 	if (headerEl.length > 0) {
 		const style = headerEl.attr("style") ?? "";
 		const bgMatch = style.match(/url\(["']?([^"')]+)["']?\)/);
-		if (bgMatch)
-			result.bannerUrl = bgMatch[1].startsWith("//")
-				? `https:${bgMatch[1]}`
-				: bgMatch[1];
+		if (bgMatch) result.bannerUrl = normalizeDevpostAssetUrl(bgMatch[1]);
 	}
 	// Also try the full-width challenge photo inside the header
 	if (!result.bannerUrl) {
 		const headerImg = $("#challenge-header img, .challenge-header img")
 			.first()
 			.attr("src");
-		if (headerImg)
-			result.bannerUrl = headerImg.startsWith("//")
-				? `https:${headerImg}`
-				: headerImg;
+		if (headerImg) result.bannerUrl = normalizeDevpostAssetUrl(headerImg);
 	}
 
 	// ---------------------------------------------------------------------------
@@ -752,8 +822,23 @@ function parseDevpostDetailPage(
 		}
 	}
 
-	const regLink = $('a[href*="register"], a[href*="signup"]').attr("href");
-	if (regLink) result.registrationUrl = regLink;
+	try {
+		const detailHost = new URL(_url).hostname;
+		$('a[href*="register"]').each((_, element) => {
+			if (result.registrationUrl) return;
+			const href = $(element).attr("href");
+			if (!href) return;
+			const candidate = new URL(href, _url);
+			if (
+				candidate.hostname === detailHost &&
+				candidate.pathname.replace(/\/+$/, "") === "/register"
+			) {
+				result.registrationUrl = candidate.toString();
+			}
+		});
+	} catch {
+		// The canonical Devpost event URL remains the registration fallback.
+	}
 
 	// ---------------------------------------------------------------------------
 	// Registration deadline
@@ -762,14 +847,26 @@ function parseDevpostDetailPage(
 		".deadline, [data-deadline], .submission-period-dates, .dates-deadline",
 	).first();
 	if (deadlineEl.length > 0) {
-		const deadlineText = deadlineEl.text().trim();
-		if (deadlineText) result.registrationDeadline = deadlineText;
+		const structuredDeadline = deadlineEl
+			.find("time[datetime]")
+			.first()
+			.attr("datetime");
+		if (structuredDeadline) {
+			const date = new Date(structuredDeadline);
+			if (!Number.isNaN(date.getTime())) {
+				result.registrationDeadline = date.toISOString();
+			}
+		}
 	}
 	if (!result.registrationDeadline) {
 		const regCloseMatch = bodyHtml.match(
 			/(?:registration(?:\s+closes)?|submissions?\s+(?:close|due|end)):?\s*([a-z]+ \d{1,2},?\s*\d{4})/i,
 		);
-		if (regCloseMatch) result.registrationDeadline = regCloseMatch[1].trim();
+		if (regCloseMatch) {
+			result.registrationDeadline = parseDevpostDateRange(
+				regCloseMatch[1].replace(/(\d{1,2})\s+(\d{4})$/, "$1, $2"),
+			).endDate;
+		}
 	}
 
 	// ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- parse Devpost date ranges into stable ISO timestamps, including ranges that cross calendar years
- normalize protocol-relative image URLs and prefer structured dates from event detail pages
- keep event-specific registration URLs while ignoring Devpost's shared account signup URL
- add focused parser and deduplication coverage

## Checkpoint
Safe real-source validation completed with:

`bun run sync:devpost --dry-run --skip-post-process`

Result:
- scraped: 175
- accepted: 175
- rejected: 0
- duplicates: 0
- needs review: 0
- would insert: 175
- inserted: 0

This run read Devpost and the existing index only. It did not write to Neon, call the AI post-processor, or deploy Trigger.dev.

## Validation
- `bun test lib/scraper/__tests__/devpost.test.ts lib/ingestion/__tests__`
- `bunx biome check lib/scraper/sources/devpost.ts lib/scraper/deduplicator.ts lib/scraper/__tests__/devpost.test.ts lib/ingestion/__tests__/deduplicator.test.ts`
- `bunx tsc --noEmit`
- `bun run build`